### PR TITLE
use -m PEM when creating SSH keys for Paramiko compatibility

### DIFF
--- a/centos7-test-container/Dockerfile
+++ b/centos7-test-container/Dockerfile
@@ -62,7 +62,7 @@ VOLUME /sys/fs/cgroup /run /tmp
 RUN ssh-keygen -q -t rsa1 -N '' -f /etc/ssh/ssh_host_key && \
     ssh-keygen -q -t dsa -N '' -f /etc/ssh/ssh_host_dsa_key && \
     ssh-keygen -q -t rsa -N '' -f /etc/ssh/ssh_host_rsa_key && \
-    ssh-keygen -q -t rsa -N '' -f /root/.ssh/id_rsa && \
+    ssh-keygen -m PEM -q -t rsa -N '' -f /root/.ssh/id_rsa && \
     cp /root/.ssh/id_rsa.pub /root/.ssh/authorized_keys && \
     for key in /etc/ssh/ssh_host_*_key.pub; do echo "localhost $(cat ${key})" >> /root/.ssh/known_hosts; done
 RUN pip install coverage junit-xml

--- a/fedora24-test-container/Dockerfile
+++ b/fedora24-test-container/Dockerfile
@@ -71,7 +71,7 @@ RUN /usr/bin/echo -e '[local]\nlocalhost ansible_connection=local' > /etc/ansibl
 VOLUME /sys/fs/cgroup /run /tmp
 RUN ssh-keygen -q -t dsa -N '' -f /etc/ssh/ssh_host_dsa_key && \
     ssh-keygen -q -t rsa -N '' -f /etc/ssh/ssh_host_rsa_key && \
-    ssh-keygen -q -t rsa -N '' -f /root/.ssh/id_rsa && \
+    ssh-keygen -m PEM -q -t rsa -N '' -f /root/.ssh/id_rsa && \
     cp /root/.ssh/id_rsa.pub /root/.ssh/authorized_keys && \
     for key in /etc/ssh/ssh_host_*_key.pub; do echo "localhost $(cat ${key})" >> /root/.ssh/known_hosts; done
 RUN pip install coverage junit-xml

--- a/fedora25-test-container/Dockerfile
+++ b/fedora25-test-container/Dockerfile
@@ -67,7 +67,7 @@ RUN /usr/bin/echo -e '[local]\nlocalhost ansible_connection=local' > /etc/ansibl
 VOLUME /sys/fs/cgroup /run /tmp
 RUN ssh-keygen -q -t dsa -N '' -f /etc/ssh/ssh_host_dsa_key && \
     ssh-keygen -q -t rsa -N '' -f /etc/ssh/ssh_host_rsa_key && \
-    ssh-keygen -q -t rsa -N '' -f /root/.ssh/id_rsa && \
+    ssh-keygen -m PEM -q -t rsa -N '' -f /root/.ssh/id_rsa && \
     cp /root/.ssh/id_rsa.pub /root/.ssh/authorized_keys && \
     for key in /etc/ssh/ssh_host_*_key.pub; do echo "localhost $(cat ${key})" >> /root/.ssh/known_hosts; done
 RUN pip install coverage junit-xml

--- a/fedora28-test-container/Dockerfile
+++ b/fedora28-test-container/Dockerfile
@@ -67,7 +67,7 @@ RUN /usr/bin/echo -e '[local]\nlocalhost ansible_connection=local' > /etc/ansibl
 VOLUME /sys/fs/cgroup /run /tmp
 RUN ssh-keygen -q -t dsa -N '' -f /etc/ssh/ssh_host_dsa_key && \
     ssh-keygen -q -t rsa -N '' -f /etc/ssh/ssh_host_rsa_key && \
-    ssh-keygen -q -t rsa -N '' -f /root/.ssh/id_rsa && \
+    ssh-keygen -m PEM -q -t rsa -N '' -f /root/.ssh/id_rsa && \
     cp /root/.ssh/id_rsa.pub /root/.ssh/authorized_keys && \
     for key in /etc/ssh/ssh_host_*_key.pub; do echo "localhost $(cat ${key})" >> /root/.ssh/known_hosts; done
 RUN pip install coverage junit-xml

--- a/fedora29-test-container/Dockerfile
+++ b/fedora29-test-container/Dockerfile
@@ -64,7 +64,7 @@ RUN /usr/bin/echo -e '[local]\nlocalhost ansible_connection=local' > /etc/ansibl
 VOLUME /sys/fs/cgroup /run /tmp
 RUN ssh-keygen -q -t dsa -N '' -f /etc/ssh/ssh_host_dsa_key && \
     ssh-keygen -q -t rsa -N '' -f /etc/ssh/ssh_host_rsa_key && \
-    ssh-keygen -q -t rsa -N '' -f /root/.ssh/id_rsa && \
+    ssh-keygen -m PEM -q -t rsa -N '' -f /root/.ssh/id_rsa && \
     cp /root/.ssh/id_rsa.pub /root/.ssh/authorized_keys && \
     for key in /etc/ssh/ssh_host_*_key.pub; do echo "localhost $(cat ${key})" >> /root/.ssh/known_hosts; done
 RUN pip3 install coverage junit-xml

--- a/opensuse42.3-test-container/Dockerfile
+++ b/opensuse42.3-test-container/Dockerfile
@@ -68,7 +68,7 @@ VOLUME /sys/fs/cgroup /run /tmp
 RUN ssh-keygen -q -t rsa1 -N '' -f /etc/ssh/ssh_host_key && \
     ssh-keygen -q -t dsa -N '' -f /etc/ssh/ssh_host_dsa_key && \
     ssh-keygen -q -t rsa -N '' -f /etc/ssh/ssh_host_rsa_key && \
-    ssh-keygen -q -t rsa -N '' -f /root/.ssh/id_rsa && \
+    ssh-keygen -m PEM -q -t rsa -N '' -f /root/.ssh/id_rsa && \
     cp /root/.ssh/id_rsa.pub /root/.ssh/authorized_keys && \
     for key in /etc/ssh/ssh_host_*_key.pub; do echo "localhost $(cat ${key})" >> /root/.ssh/known_hosts; done
 # explicitly enable the service, opensuse default to disabled services

--- a/ubuntu1404-test-container/Dockerfile
+++ b/ubuntu1404-test-container/Dockerfile
@@ -89,7 +89,7 @@ RUN rm /etc/apt/apt.conf.d/docker-clean
 RUN mkdir /etc/ansible/
 RUN /bin/echo -e "[local]\nlocalhost ansible_connection=local" > /etc/ansible/hosts
 RUN locale-gen en_US.UTF-8
-RUN ssh-keygen -q -t rsa -N '' -f /root/.ssh/id_rsa && \
+RUN ssh-keygen -m PEM -q -t rsa -N '' -f /root/.ssh/id_rsa && \
     cp /root/.ssh/id_rsa.pub /root/.ssh/authorized_keys && \
     for key in /etc/ssh/ssh_host_*_key.pub; do echo "localhost $(cat ${key})" >> /root/.ssh/known_hosts; done
 VOLUME /sys/fs/cgroup /run/lock /run /tmp

--- a/ubuntu1604-test-container/Dockerfile
+++ b/ubuntu1604-test-container/Dockerfile
@@ -64,7 +64,7 @@ RUN rm /etc/apt/apt.conf.d/docker-clean
 RUN mkdir /etc/ansible/
 RUN /bin/echo -e "[local]\nlocalhost ansible_connection=local" > /etc/ansible/hosts
 RUN locale-gen en_US.UTF-8
-RUN ssh-keygen -q -t rsa -N '' -f /root/.ssh/id_rsa && \
+RUN ssh-keygen -m PEM -q -t rsa -N '' -f /root/.ssh/id_rsa && \
     cp /root/.ssh/id_rsa.pub /root/.ssh/authorized_keys && \
     for key in /etc/ssh/ssh_host_*_key.pub; do echo "localhost $(cat ${key})" >> /root/.ssh/known_hosts; done
 VOLUME /sys/fs/cgroup /run/lock /run /tmp

--- a/ubuntu1604py3-test-container/Dockerfile
+++ b/ubuntu1604py3-test-container/Dockerfile
@@ -60,7 +60,7 @@ RUN rm /etc/apt/apt.conf.d/docker-clean
 RUN mkdir /etc/ansible/
 RUN /bin/echo -e "[local]\nlocalhost ansible_connection=local" > /etc/ansible/hosts
 RUN locale-gen en_US.UTF-8
-RUN ssh-keygen -q -t rsa -N '' -f /root/.ssh/id_rsa && \
+RUN ssh-keygen -m PEM -q -t rsa -N '' -f /root/.ssh/id_rsa && \
     cp /root/.ssh/id_rsa.pub /root/.ssh/authorized_keys && \
     for key in /etc/ssh/ssh_host_*_key.pub; do echo "localhost $(cat ${key})" >> /root/.ssh/known_hosts; done
 VOLUME /sys/fs/cgroup /run/lock /run /tmp


### PR DESCRIPTION
To fix the paramiko tests on newer Fedora hosts we use `-m PEM` to enfore the supported private key format.