### PR TITLE
fix up a yum issue with Fedora 29

### DIFF
--- a/fedora29-test-container/Dockerfile
+++ b/fedora29-test-container/Dockerfile
@@ -7,7 +7,9 @@ rm -f /lib/systemd/system/local-fs.target.wants/*; \
 rm -f /lib/systemd/system/sockets.target.wants/*udev*; \
 rm -f /lib/systemd/system/sockets.target.wants/*initctl*; \
 rm -f /lib/systemd/system/basic.target.wants/*; \
-rm -f /lib/systemd/system/anaconda.target.wants/*;
+rm -f /lib/systemd/system/anaconda.target.wants/*; \
+# dnf upgrade will upgrade dnf-yum and it remove /etc/yum.conf take a backup and restore after the upgrade
+cp /etc/yum.conf /etc/yum.conf.bak;
 
 RUN dnf clean all && \
     dnf -y upgrade && \
@@ -55,7 +57,9 @@ RUN dnf clean all && \
     which \
     zip \
     && \
-    dnf clean all
+    dnf clean all \
+    && \
+    mv /etc/yum.conf.bak /etc/yum.conf -f
 
 RUN localedef --quiet -c -i en_US -f UTF-8 en_US.UTF-8
 RUN /usr/bin/sed -i -e 's/^\(Defaults\s*requiretty\)/#--- \1/'  /etc/sudoers


### PR DESCRIPTION
Due to https://src.fedoraproject.org/rpms/dnf/c/8ce1a7c6acbc892e92135f90118f12c200bdf2c2, upgrading the `dnf-yum` package will result in `/etc/yum.conf` being deleted and that's required by the Ansible test. As Fedora 29 comes with v 4.0.3  and the upgrade goes to 4.0.4 I assume the base package has manually created the conf file so we just store a backup and restore for the image.

This won't be an issue for F30 as the exclude check if for `Fedora <= 30`.