### PR TITLE
ensure coreutils is installed instead of coreutils-simple

### DIFF
--- a/fedora28-test-container/Dockerfile
+++ b/fedora28-test-container/Dockerfile
@@ -10,6 +10,7 @@ rm -f /lib/systemd/system/basic.target.wants/*; \
 rm -f /lib/systemd/system/anaconda.target.wants/*;
 
 RUN dnf clean all && \
+    dnf -y --allowerasing install coreutils && \
     dnf -y --setopt=install_weak_deps=false install \
     acl \
     asciidoc \

--- a/fedora29-test-container/Dockerfile
+++ b/fedora29-test-container/Dockerfile
@@ -11,6 +11,7 @@ rm -f /lib/systemd/system/anaconda.target.wants/*;
 
 RUN dnf clean all && \
     dnf -y upgrade && \
+    dnf -y --allowerasing install coreutils && \
     dnf -y --setopt=install_weak_deps=false install \
     acl \
     bzip2 \


### PR DESCRIPTION
Since Fedora 28 `coreutils-simple` is installed instead of `coreutils`. This changes those containers to install `coreutils` and replace the simple package for compatibility with the the CI test suite.

This is really just an issue with the `dnf` tests where it goes to install `@Web Server` which has a dependency on `coreutils`.