### PR TITLE
add systemd package and changed init path

### DIFF
--- a/ubuntu1804-test-container/Dockerfile
+++ b/ubuntu1804-test-container/Dockerfile
@@ -48,6 +48,7 @@ RUN apt-get update -y && \
     sshpass \
     subversion \
     sudo \
+    systemd \
     tzdata \
     unzip \
     virtualenv \
@@ -66,4 +67,4 @@ RUN ssh-keygen -m PEM -q -t rsa -N '' -f /root/.ssh/id_rsa && \
 VOLUME /sys/fs/cgroup /run/lock /run /tmp
 RUN pip3 install coverage junit-xml python3-keyczar
 ENV container=docker
-CMD ["/sbin/init"]
+CMD ["/lib/systemd/systemd"]


### PR DESCRIPTION
Since Ubuntu 16.10, the base container image does not contain the systemd package. This PR makes sure it is installed and the entrypoint cmd calls that.