### PR TITLE
Add OpenSUSE 15.0 to distro containers

### DIFF
--- a/opensuse15-test-container/Dockerfile
+++ b/opensuse15-test-container/Dockerfile
@@ -59,13 +59,6 @@ rm -f ${LIBSYSTEMD}/basic.target.wants/*;
 # don't create systemd-session for ssh connections
 RUN sed -i /pam_systemd/d /etc/pam.d/common-session-pc
 
-# need to create the nobody user and group as it's used in some Ansible tests
-# this user exists in the OpenSUSE Leap 15.0 VM it's just removed in the base contianer
-RUN groupadd -g 65534 nobody && \
-    useradd nobody -d /var/lib/nobody -s /bin/bash -c nobody -u 65534 -g 65534 && \
-    mkdir /var/lib/nobody && \
-    chown nobody /var/lib/nobody
-
 RUN mkdir /etc/ansible/
 RUN /usr/bin/echo -e '[local]\nlocalhost ansible_connection=local' > /etc/ansible/hosts
 VOLUME /sys/fs/cgroup /run /tmp

--- a/opensuse15-test-container/Dockerfile
+++ b/opensuse15-test-container/Dockerfile
@@ -59,6 +59,13 @@ rm -f ${LIBSYSTEMD}/basic.target.wants/*;
 # don't create systemd-session for ssh connections
 RUN sed -i /pam_systemd/d /etc/pam.d/common-session-pc
 
+# need to create the nobody user and group as it's used in some Ansible tests
+# this user exists in the OpenSUSE Leap 15.0 VM it's just removed in the base contianer
+RUN groupadd -g 65534 nobody && \
+    useradd nobody -d /var/lib/nobody -s /bin/bash -c nobody -u 65534 -g 65534 && \
+    mkdir /var/lib/nobody && \
+    chown nobody /var/lib/nobody
+
 RUN mkdir /etc/ansible/
 RUN /usr/bin/echo -e '[local]\nlocalhost ansible_connection=local' > /etc/ansible/hosts
 VOLUME /sys/fs/cgroup /run /tmp

--- a/opensuse15-test-container/Dockerfile
+++ b/opensuse15-test-container/Dockerfile
@@ -5,10 +5,9 @@ RUN zypper --non-interactive --gpg-auto-import-keys refresh --services --force &
     zypper --non-interactive install --auto-agree-with-licenses --no-recommends \
     acl \
     apache2 \
-    asciidoc \
     bzip2 \
     curl \
-    dbus-1-python \
+    dbus-1-python3 \
     gcc \
     git \
     glibc-i18ndata \
@@ -17,25 +16,24 @@ RUN zypper --non-interactive --gpg-auto-import-keys refresh --services --force &
     lsb-release \
     make \
     mariadb \
-    mercurial \
     openssh \
     postgresql-server \
-    python-cryptography \
-    python-devel \
-    python-httplib2 \
-    python-jinja2 \
-    python-keyczar \
-    python-lxml \
-    python-mock \
-    python-PyMySQL \
-    python-nose \
-    python-paramiko \
-    python-passlib \
-    python-pip \
-    python-psycopg2 \
-    python-PyYAML \
-    python-setuptools \
-    python-virtualenv \
+    python3-cryptography \
+    python3-devel \
+    python3-httplib2 \
+    python3-Jinja2 \
+    python3-keyczar \
+    python3-lxml \
+    python3-mock \
+    python3-PyMySQL \
+    python3-nose \
+    python3-paramiko \
+    python3-passlib \
+    python3-pip \
+    python3-psycopg2 \
+    python3-PyYAML \
+    python3-setuptools \
+    python3-virtualenv \
     rpm-build \
     ruby \
     sshpass \

--- a/opensuse15.0-test-container/Dockerfile
+++ b/opensuse15.0-test-container/Dockerfile
@@ -1,0 +1,78 @@
+FROM opensuse/leap:15.0
+
+RUN zypper --non-interactive --gpg-auto-import-keys refresh --services --force && \
+    zypper --non-interactive install --force systemd-sysvinit && \
+    zypper --non-interactive install --auto-agree-with-licenses --no-recommends \
+    acl \
+    apache2 \
+    asciidoc \
+    bzip2 \
+    curl \
+    dbus-1-python \
+    gcc \
+    git \
+    glibc-i18ndata \
+    glibc-locale \
+    iproute2 \
+    lsb-release \
+    make \
+    mariadb \
+    mercurial \
+    openssh \
+    postgresql-server \
+    python-cryptography \
+    python-devel \
+    python-httplib2 \
+    python-jinja2 \
+    python-keyczar \
+    python-lxml \
+    python-mock \
+    python-PyMySQL \
+    python-nose \
+    python-paramiko \
+    python-passlib \
+    python-pip \
+    python-psycopg2 \
+    python-PyYAML \
+    python-setuptools \
+    python-virtualenv \
+    rpm-build \
+    ruby \
+    sshpass \
+    subversion \
+    sudo \
+    tar \
+    unzip \
+    which \
+    zip \
+    && \
+    zypper clean --all
+
+# systemd path differs from rhel
+ENV LIBSYSTEMD=/usr/lib/systemd/system
+RUN (cd ${LIBSYSTEMD}/sysinit.target.wants/; for i in *; do [ $i == systemd-tmpfiles-setup.service ] || rm -f $i; done); \
+rm -f ${LIBSYSTEMD}/multi-user.target.wants/*; \
+rm -f /etc/systemd/system/*.wants/*; \
+rm -f ${LIBSYSTEMD}/local-fs.target.wants/*; \
+rm -f ${LIBSYSTEMD}/sockets.target.wants/*udev*; \
+rm -f ${LIBSYSTEMD}/sockets.target.wants/*initctl*; \
+rm -f ${LIBSYSTEMD}/basic.target.wants/*;
+
+# don't create systemd-session for ssh connections
+RUN sed -i /pam_systemd/d /etc/pam.d/common-session-pc
+
+RUN mkdir /etc/ansible/
+RUN /usr/bin/echo -e '[local]\nlocalhost ansible_connection=local' > /etc/ansible/hosts
+VOLUME /sys/fs/cgroup /run /tmp
+RUN ssh-keygen -q -t dsa -N '' -f /etc/ssh/ssh_host_dsa_key && \
+    ssh-keygen -q -t rsa -N '' -f /etc/ssh/ssh_host_rsa_key && \
+    ssh-keygen -q -t ecdsa -N '' -f /etc/ssh/ssh_host_ecdsa_key && \
+    ssh-keygen -q -t ed25519 -N '' -f /etc/ssh/ssh_host_ed25519_key && \
+    ssh-keygen -m PEM -q -t rsa -N '' -f /root/.ssh/id_rsa && \
+    cp /root/.ssh/id_rsa.pub /root/.ssh/authorized_keys && \
+    for key in /etc/ssh/ssh_host_*_key.pub; do echo "localhost $(cat ${key})" >> /root/.ssh/known_hosts; done
+# explicitly enable the service, opensuse default to disabled services
+RUN systemctl enable sshd.service
+RUN pip install coverage junit-xml
+ENV container=docker
+CMD ["/sbin/init"]

--- a/opensuse15py2-test-container/Dockerfile
+++ b/opensuse15py2-test-container/Dockerfile
@@ -1,0 +1,77 @@
+FROM opensuse/leap:15.0
+
+RUN zypper --non-interactive --gpg-auto-import-keys refresh --services --force && \
+    zypper --non-interactive install --force systemd-sysvinit && \
+    zypper --non-interactive install --auto-agree-with-licenses --no-recommends \
+    acl \
+    apache2 \
+    bzip2 \
+    curl \
+    dbus-1-python \
+    gcc \
+    git \
+    glibc-i18ndata \
+    glibc-locale \
+    iproute2 \
+    lsb-release \
+    make \
+    mariadb \
+    mercurial \
+    openssh \
+    postgresql-server \
+    python-cryptography \
+    python-devel \
+    python-httplib2 \
+    python-jinja2 \
+    python-keyczar \
+    python-lxml \
+    python-mock \
+    python-PyMySQL \
+    python-nose \
+    python-paramiko \
+    python-passlib \
+    python-pip \
+    python-psycopg2 \
+    python-PyYAML \
+    python-setuptools \
+    python-virtualenv \
+    rpm-build \
+    ruby \
+    sshpass \
+    subversion \
+    sudo \
+    tar \
+    unzip \
+    which \
+    zip \
+    && \
+    zypper clean --all
+
+# systemd path differs from rhel
+ENV LIBSYSTEMD=/usr/lib/systemd/system
+RUN (cd ${LIBSYSTEMD}/sysinit.target.wants/; for i in *; do [ $i == systemd-tmpfiles-setup.service ] || rm -f $i; done); \
+rm -f ${LIBSYSTEMD}/multi-user.target.wants/*; \
+rm -f /etc/systemd/system/*.wants/*; \
+rm -f ${LIBSYSTEMD}/local-fs.target.wants/*; \
+rm -f ${LIBSYSTEMD}/sockets.target.wants/*udev*; \
+rm -f ${LIBSYSTEMD}/sockets.target.wants/*initctl*; \
+rm -f ${LIBSYSTEMD}/basic.target.wants/*;
+
+# don't create systemd-session for ssh connections
+RUN sed -i /pam_systemd/d /etc/pam.d/common-session-pc
+
+RUN mkdir /etc/ansible/
+RUN /usr/bin/echo -e '[local]\nlocalhost ansible_connection=local' > /etc/ansible/hosts
+VOLUME /sys/fs/cgroup /run /tmp
+RUN ssh-keygen -q -t dsa -N '' -f /etc/ssh/ssh_host_dsa_key && \
+    ssh-keygen -q -t rsa -N '' -f /etc/ssh/ssh_host_rsa_key && \
+    ssh-keygen -q -t ecdsa -N '' -f /etc/ssh/ssh_host_ecdsa_key && \
+    ssh-keygen -q -t ed25519 -N '' -f /etc/ssh/ssh_host_ed25519_key && \
+    ssh-keygen -m PEM -q -t rsa -N '' -f /root/.ssh/id_rsa && \
+    cp /root/.ssh/id_rsa.pub /root/.ssh/authorized_keys && \
+    for key in /etc/ssh/ssh_host_*_key.pub; do echo "localhost $(cat ${key})" >> /root/.ssh/known_hosts; done
+# explicitly enable the service, opensuse default to disabled services
+RUN systemctl enable sshd.service
+RUN pip install coverage junit-xml
+ENV container=docker
+CMD ["/sbin/init"]

--- a/opensuse15py2-test-container/Dockerfile
+++ b/opensuse15py2-test-container/Dockerfile
@@ -60,6 +60,13 @@ rm -f ${LIBSYSTEMD}/basic.target.wants/*;
 # don't create systemd-session for ssh connections
 RUN sed -i /pam_systemd/d /etc/pam.d/common-session-pc
 
+# need to create the nobody user and group as it's used in some Ansible tests
+# this user exists in the OpenSUSE Leap 15.0 VM it's just removed in the base contianer
+RUN groupadd -g 65534 nobody && \
+    useradd nobody -d /var/lib/nobody -s /bin/bash -c nobody -u 65534 -g 65534 && \
+    mkdir /var/lib/nobody && \
+    chown nobody /var/lib/nobody
+
 RUN mkdir /etc/ansible/
 RUN /usr/bin/echo -e '[local]\nlocalhost ansible_connection=local' > /etc/ansible/hosts
 VOLUME /sys/fs/cgroup /run /tmp

--- a/opensuse15py2-test-container/Dockerfile
+++ b/opensuse15py2-test-container/Dockerfile
@@ -60,13 +60,6 @@ rm -f ${LIBSYSTEMD}/basic.target.wants/*;
 # don't create systemd-session for ssh connections
 RUN sed -i /pam_systemd/d /etc/pam.d/common-session-pc
 
-# need to create the nobody user and group as it's used in some Ansible tests
-# this user exists in the OpenSUSE Leap 15.0 VM it's just removed in the base contianer
-RUN groupadd -g 65534 nobody && \
-    useradd nobody -d /var/lib/nobody -s /bin/bash -c nobody -u 65534 -g 65534 && \
-    mkdir /var/lib/nobody && \
-    chown nobody /var/lib/nobody
-
 RUN mkdir /etc/ansible/
 RUN /usr/bin/echo -e '[local]\nlocalhost ansible_connection=local' > /etc/ansible/hosts
 VOLUME /sys/fs/cgroup /run /tmp

--- a/shippable.yml
+++ b/shippable.yml
@@ -8,6 +8,8 @@ env:
   - C: fedora28
   - C: fedora29
   - C: opensuse42.3
+  - C: opensuse15py2
+  - C: opensuse15
   - C: ubuntu1404
   - C: ubuntu1604
   - C: ubuntu1604py3


### PR DESCRIPTION
Adds the OpenSUSE 15.0 distro to our list of test containers. There is still a question as to whether this should be running Python 2 or 3. When installing Ansible with `zypper install ansible` Python 2 is used, but so far 1 test, `cloud_init_data_facts` requires Python3 on this version breaking our integration build.

This is currently a copy of the OpenSUSE 42.3 container without the `python-MySQL-Python` and `password-store` package as they don't exist on this version and an updated list of SSH host key algorithms used.