### PR TITLE
Add rubygem-rdoc to Fedora 30 image

### DIFF
--- a/fedora30-test-container/Dockerfile
+++ b/fedora30-test-container/Dockerfile
@@ -47,6 +47,7 @@ RUN dnf clean all && \
     python3-virtualenv \
     rpm-build \
     rubygems \
+    rubygem-rdoc \
     sshpass \
     subversion \
     sudo \


### PR DESCRIPTION
`gem` 3.0.0 [removed the bundled version of `rdoc`](https://github.com/rubygems/rubygems/commit/b9da176dda753d5dbcd350340a63a60ec52b2aa0), which causes `gem uninstall` to fail. Fedora 30 installs gem 3.0.3, so any attempt to uninstall a gem in Fedora 30 fails if `rdoc` is not installed.

This is [fixed upstream](https://github.com/rubygems/rubygems/pull/2604) but has not been released yet.

https://github.com/rubygems/rubygems/issues/2483