### PR TITLE
fedora: enable dnf fastestmirror plugin

### DIFF
--- a/fedora30-test-container/Dockerfile
+++ b/fedora30-test-container/Dockerfile
@@ -9,6 +9,8 @@ rm -f /lib/systemd/system/sockets.target.wants/*initctl*; \
 rm -f /lib/systemd/system/basic.target.wants/*; \
 rm -f /lib/systemd/system/anaconda.target.wants/*;
 
+RUN echo 'fastestmirror=true' >> /etc/dnf/dnf.conf
+
 RUN dnf clean all && \
     dnf -y upgrade && \
     dnf -y --allowerasing install coreutils && \


### PR DESCRIPTION
Enable dnf 's fastestmirror option in the Fedora30 container.