### PR TITLE
CentOS 7 image improvements

### DIFF
--- a/centos7-test-container/Dockerfile
+++ b/centos7-test-container/Dockerfile
@@ -35,7 +35,7 @@ RUN yum clean all && \
     python-lxml \
     python-mock \
     python-nose \
-    python-passlib \
+    python2-passlib \
     python-pip \
     python-setuptools \
     python-virtualenv \
@@ -48,7 +48,6 @@ RUN yum clean all && \
     unzip \
     which \
     && \
-    yum -y swap fakesystemd systemd && \
     yum clean all
 
 RUN /usr/bin/sed -i -e 's/^\(Defaults\s*requiretty\)/#--- \1/'  /etc/sudoers

--- a/centos7-test-container/Dockerfile
+++ b/centos7-test-container/Dockerfile
@@ -48,7 +48,11 @@ RUN yum clean all && \
     unzip \
     which \
     && \
-    yum clean all
+    yum clean all && \
+    rm -rf /usr/share/fonts/* \
+        /usr/share/i18n/* \
+        /usr/share/sgml/docbook/xsl-stylesheets* \
+        /usr/share/adobe/resources/*
 
 RUN /usr/bin/sed -i -e 's/^\(Defaults\s*requiretty\)/#--- \1/'  /etc/sudoers
 RUN mkdir /etc/ansible/

--- a/centos7-test-container/Dockerfile
+++ b/centos7-test-container/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:7.7.1908
+FROM centos:7.6.1810
 
 RUN (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i == systemd-tmpfiles-setup.service ] || rm -f $i; done); \
 rm -f /lib/systemd/system/multi-user.target.wants/*; \


### PR DESCRIPTION
- fix a package name
- no longer switch to `fakesystemd`
- cleanup some resources to reduce image size