### PR TITLE
Remove pass package from CentOS images

### DIFF
--- a/centos6-test-container/Dockerfile
+++ b/centos6-test-container/Dockerfile
@@ -20,7 +20,6 @@ RUN yum clean all && \
     openssh-server \
     openssl-devel \
     python-argparse \
-    pass \
     python-devel \
     python-httplib2 \
     python-jinja2 \

--- a/centos7-test-container/Dockerfile
+++ b/centos7-test-container/Dockerfile
@@ -30,7 +30,6 @@ RUN yum clean all && \
     openssh-server \
     openssl-devel \
     python-cryptography \
-    pass \
     python-devel \
     python-httplib2 \
     python-jinja2 \


### PR DESCRIPTION
It is no longer available in EPEL, so do not try to install it.
https://lists.zx2c4.com/pipermail/password-store/2019-July/003689.html

The integration test relying on this package has been updated to skip CentOS.