### PR TITLE
Remove MySQL packages

### DIFF
--- a/centos6-test-container/Dockerfile
+++ b/centos6-test-container/Dockerfile
@@ -13,9 +13,6 @@ RUN yum clean all && \
     libffi-devel \
     make \
     mercurial \
-    mysql \
-    MySQL-python \
-    mysql-server \
     openssh-clients \
     openssh-server \
     openssl-devel \

--- a/centos7-test-container/Dockerfile
+++ b/centos7-test-container/Dockerfile
@@ -23,9 +23,7 @@ RUN yum clean all && \
     libffi \
     libffi-devel \
     make \
-    mariadb-server \
     mercurial \
-    MySQL-python \
     openssh-clients \
     openssh-server \
     openssl-devel \

--- a/fedora30-test-container/Dockerfile
+++ b/fedora30-test-container/Dockerfile
@@ -24,7 +24,6 @@ RUN dnf clean all && \
     libffi \
     libffi-devel \
     make \
-    mariadb-server \
     openssh-clients \
     openssh-server \
     openssl-devel \
@@ -38,7 +37,6 @@ RUN dnf clean all && \
     python3-jinja2 \
     python3-lxml \
     python3-mock \
-    python3-mysql \
     python3-nose \
     python3-passlib \
     python3-pip \

--- a/opensuse15-test-container/Dockerfile
+++ b/opensuse15-test-container/Dockerfile
@@ -15,7 +15,6 @@ RUN zypper --non-interactive --gpg-auto-import-keys refresh --services --force &
     iproute2 \
     lsb-release \
     make \
-    mariadb \
     openssh \
     postgresql-server \
     python3-cryptography \
@@ -25,7 +24,6 @@ RUN zypper --non-interactive --gpg-auto-import-keys refresh --services --force &
     python3-keyczar \
     python3-lxml \
     python3-mock \
-    python3-PyMySQL \
     python3-nose \
     python3-passlib \
     python3-pip \

--- a/opensuse15py2-test-container/Dockerfile
+++ b/opensuse15py2-test-container/Dockerfile
@@ -15,7 +15,6 @@ RUN zypper --non-interactive --gpg-auto-import-keys refresh --services --force &
     iproute2 \
     lsb-release \
     make \
-    mariadb \
     mercurial \
     openssh \
     postgresql-server \
@@ -26,7 +25,6 @@ RUN zypper --non-interactive --gpg-auto-import-keys refresh --services --force &
     python-keyczar \
     python-lxml \
     python-mock \
-    python-PyMySQL \
     python-nose \
     python-passlib \
     python-pip \

--- a/ubuntu1604-test-container/Dockerfile
+++ b/ubuntu1604-test-container/Dockerfile
@@ -25,7 +25,6 @@ RUN apt-get update -y && \
     lsb-release \
     make \
     mercurial \
-    mysql-server \
     openssh-client \
     openssh-server \
     python-cryptography \
@@ -37,7 +36,6 @@ RUN apt-get update -y && \
     python-keyczar \
     python-lxml \
     python-mock \
-    python-mysqldb \
     python-nose \
     python-passlib \
     python-pip \

--- a/ubuntu1804-test-container/Dockerfile
+++ b/ubuntu1804-test-container/Dockerfile
@@ -22,7 +22,6 @@ RUN apt-get update -y && \
     locales \
     lsb-release \
     make \
-    mysql-server \
     pass \
     openssh-client \
     openssh-server \
@@ -33,7 +32,6 @@ RUN apt-get update -y && \
     python3-jinja2 \
     python3-lxml \
     python3-mock \
-    python3-mysqldb \
     python3-nose \
     python3-passlib \
     python3-pip \


### PR DESCRIPTION
The proper packages are installed by integration test roles, which are from the MySQL/MariaDB repos and not from EPEL.