### PR TITLE
Update Fedora 30

### DIFF
--- a/fedora30-test-container/Dockerfile
+++ b/fedora30-test-container/Dockerfile
@@ -25,11 +25,8 @@ RUN dnf clean all && \
     libffi-devel \
     make \
     mariadb-server \
-    # OpenSSH 8.0 generates PEM keys in PKCS8 format, which Paramiko does not recognize
-    # https://bugzilla.redhat.com/show_bug.cgi?id=1722285
-    # https://github.com/paramiko/paramiko/issues/1015
-    openssh-clients-7.9p1 \
-    openssh-server-7.9p1 \
+    openssh-clients \
+    openssh-server \
     openssl-devel \
     pass \
     procps \
@@ -71,12 +68,6 @@ RUN ssh-keygen -q -t dsa -N '' -f /etc/ssh/ssh_host_dsa_key && \
     ssh-keygen -m PEM -q -t rsa -N '' -f /root/.ssh/id_rsa && \
     cp /root/.ssh/id_rsa.pub /root/.ssh/authorized_keys && \
     for key in /etc/ssh/ssh_host_*_key.pub; do echo "localhost $(cat ${key})" >> /root/.ssh/known_hosts; done
-# Update to the latest version of OpenSSH once the key is generated
-RUN dnf -y update \
-    openssh-clients \
-    openssh-server \
-    && \
-    dnf clean all
 RUN pip3 install coverage junit-xml
 ENV container=docker
 CMD ["/usr/sbin/init"]


### PR DESCRIPTION
There is no longer a need to install `openssh` 7.9, generate the key,
then upgrade to `openssh` 8.0. The bug that causes problems with paramiko
was fixed in `openssh-8.0p1-5.fc30`

https://bugzilla.redhat.com/show_bug.cgi?id=1722285

I ran the `connection_paramiko_ssh` integration test with this image and it passes. Before it was failing when `paramiko` failed to parse the header in the key file.