### PR TITLE
Add packaging library to images

### DIFF
--- a/centos6-test-container/Dockerfile
+++ b/centos6-test-container/Dockerfile
@@ -54,6 +54,6 @@ RUN ssh-keygen -q -t rsa1 -N '' -f /etc/ssh/ssh_host_key && \
     ssh-keygen -q -t rsa -N '' -f /root/.ssh/id_rsa && \
     cp /root/.ssh/id_rsa.pub /root/.ssh/authorized_keys && \
     for key in /etc/ssh/ssh_host_*_key.pub; do echo "localhost $(cat ${key})" >> /root/.ssh/known_hosts; done
-RUN pip install 'coverage<5' junit-xml packaging
+RUN pip install 'coverage<5' junit-xml 'packaging==20.04'
 ENV container=docker
 CMD ["/sbin/init"]

--- a/centos6-test-container/Dockerfile
+++ b/centos6-test-container/Dockerfile
@@ -54,6 +54,6 @@ RUN ssh-keygen -q -t rsa1 -N '' -f /etc/ssh/ssh_host_key && \
     ssh-keygen -q -t rsa -N '' -f /root/.ssh/id_rsa && \
     cp /root/.ssh/id_rsa.pub /root/.ssh/authorized_keys && \
     for key in /etc/ssh/ssh_host_*_key.pub; do echo "localhost $(cat ${key})" >> /root/.ssh/known_hosts; done
-RUN pip install 'coverage<5' junit-xml 'packaging==20.04'
+RUN pip install 'coverage<5' junit-xml 'packaging==16.8'
 ENV container=docker
 CMD ["/sbin/init"]

--- a/centos6-test-container/Dockerfile
+++ b/centos6-test-container/Dockerfile
@@ -54,6 +54,6 @@ RUN ssh-keygen -q -t rsa1 -N '' -f /etc/ssh/ssh_host_key && \
     ssh-keygen -q -t rsa -N '' -f /root/.ssh/id_rsa && \
     cp /root/.ssh/id_rsa.pub /root/.ssh/authorized_keys && \
     for key in /etc/ssh/ssh_host_*_key.pub; do echo "localhost $(cat ${key})" >> /root/.ssh/known_hosts; done
-RUN pip install 'coverage<5' junit-xml
+RUN pip install 'coverage<5' junit-xml packaging
 ENV container=docker
 CMD ["/sbin/init"]

--- a/centos7-test-container/Dockerfile
+++ b/centos7-test-container/Dockerfile
@@ -35,6 +35,7 @@ RUN yum clean all && \
     python-lxml \
     python-mock \
     python-nose \
+    python2-packaging \
     python2-passlib \
     python-pip \
     python-setuptools \

--- a/centos8-test-container/Dockerfile
+++ b/centos8-test-container/Dockerfile
@@ -72,6 +72,6 @@ RUN ssh-keygen -q -t dsa -N '' -f /etc/ssh/ssh_host_dsa_key && \
     ssh-keygen -m PEM -q -t rsa -N '' -f /root/.ssh/id_rsa && \
     cp /root/.ssh/id_rsa.pub /root/.ssh/authorized_keys && \
     for key in /etc/ssh/ssh_host_*_key.pub; do echo "localhost $(cat ${key})" >> /root/.ssh/known_hosts; done
-RUN pip3 install 'coverage<5' junit-xml packaging
+RUN pip3 install 'coverage<5' junit-xml 'packaging==20.04'
 ENV container=docker
 CMD ["/usr/sbin/init"]

--- a/centos8-test-container/Dockerfile
+++ b/centos8-test-container/Dockerfile
@@ -17,7 +17,7 @@ RUN dnf clean all && \
     # Simply running dnf -y --allowerasing install coreutils resulted in a corrupt rpmdb
     rpm -e --nodeps coreutils-single && \
     dnf -y install epel-release && \
-    dnf -y --setopt=install_weak_deps=false install \
+    dnf -y --setopt=install_weak_deps=false --enablerepo=PowerTools install \
     acl \
     asciidoc \
     coreutils \
@@ -42,6 +42,7 @@ RUN dnf clean all && \
     python3-lxml \
     python3-nose \
     python3-pip \
+    python3-packaging \
     python3-pyyaml \
     python3-setuptools \
     python3-virtualenv \
@@ -72,6 +73,6 @@ RUN ssh-keygen -q -t dsa -N '' -f /etc/ssh/ssh_host_dsa_key && \
     ssh-keygen -m PEM -q -t rsa -N '' -f /root/.ssh/id_rsa && \
     cp /root/.ssh/id_rsa.pub /root/.ssh/authorized_keys && \
     for key in /etc/ssh/ssh_host_*_key.pub; do echo "localhost $(cat ${key})" >> /root/.ssh/known_hosts; done
-RUN pip3 install 'coverage<5' junit-xml 'packaging==20.04'
+RUN pip3 install 'coverage<5' junit-xml
 ENV container=docker
 CMD ["/usr/sbin/init"]

--- a/centos8-test-container/Dockerfile
+++ b/centos8-test-container/Dockerfile
@@ -72,6 +72,6 @@ RUN ssh-keygen -q -t dsa -N '' -f /etc/ssh/ssh_host_dsa_key && \
     ssh-keygen -m PEM -q -t rsa -N '' -f /root/.ssh/id_rsa && \
     cp /root/.ssh/id_rsa.pub /root/.ssh/authorized_keys && \
     for key in /etc/ssh/ssh_host_*_key.pub; do echo "localhost $(cat ${key})" >> /root/.ssh/known_hosts; done
-RUN pip3 install 'coverage<5' junit-xml
+RUN pip3 install 'coverage<5' junit-xml packaging
 ENV container=docker
 CMD ["/usr/sbin/init"]

--- a/fedora30-test-container/Dockerfile
+++ b/fedora30-test-container/Dockerfile
@@ -38,6 +38,7 @@ RUN dnf clean all && \
     python3-lxml \
     python3-mock \
     python3-nose \
+    python3-packaging \
     python3-passlib \
     python3-pip \
     python3-PyYAML \

--- a/fedora31-test-container/Dockerfile
+++ b/fedora31-test-container/Dockerfile
@@ -38,6 +38,7 @@ RUN dnf clean all && \
     python3-lxml \
     python3-mock \
     python3-nose \
+    python3-packaging \
     python3-passlib \
     python3-pip \
     python3-PyYAML \

--- a/fedora32-test-container/Dockerfile
+++ b/fedora32-test-container/Dockerfile
@@ -38,6 +38,7 @@ RUN dnf clean all && \
     python3-lxml \
     python3-mock \
     python3-nose \
+    python3-packaging \
     python3-passlib \
     python3-pip \
     python3-PyYAML \

--- a/opensuse15-test-container/Dockerfile
+++ b/opensuse15-test-container/Dockerfile
@@ -25,6 +25,7 @@ RUN zypper --non-interactive --gpg-auto-import-keys refresh --services --force &
     python3-lxml \
     python3-mock \
     python3-nose \
+    python3-packaging \
     python3-passlib \
     python3-pip \
     python3-psycopg2 \

--- a/opensuse15py2-test-container/Dockerfile
+++ b/opensuse15py2-test-container/Dockerfile
@@ -26,6 +26,7 @@ RUN zypper --non-interactive --gpg-auto-import-keys refresh --services --force &
     python-lxml \
     python-mock \
     python-nose \
+    python2-packaging \
     python-passlib \
     python-pip \
     python-psycopg2 \

--- a/ubuntu1604-test-container/Dockerfile
+++ b/ubuntu1604-test-container/Dockerfile
@@ -37,6 +37,7 @@ RUN apt-get update -y && \
     python-lxml \
     python-mock \
     python-nose \
+    python-packaging \
     python-passlib \
     python-pip \
     python-setuptools \

--- a/ubuntu1804-test-container/Dockerfile
+++ b/ubuntu1804-test-container/Dockerfile
@@ -33,6 +33,7 @@ RUN apt-get update -y && \
     python3-lxml \
     python3-mock \
     python3-nose \
+    python3-packaging \
     python3-passlib \
     python3-pip \
     python3-setuptools \

--- a/ubuntu2004-test-container/Dockerfile
+++ b/ubuntu2004-test-container/Dockerfile
@@ -33,6 +33,7 @@ RUN apt-get update -y && \
     python3-lxml \
     python3-mock \
     python3-nose \
+    python3-packaging \
     python3-passlib \
     python3-pip \
     python3-setuptools \


### PR DESCRIPTION
This was recently added as a dep for Ansible. Add to test images so it doesn't need to be installed every time.

I was only unable to find OS packages for CentOS 6 and CentOS 8.