### PR TITLE
Exclude sshpass from container

### DIFF
--- a/alpine3-test-container/Dockerfile
+++ b/alpine3-test-container/Dockerfile
@@ -3,7 +3,8 @@ FROM alpine:3.12.0
 # Keep this as basic as possible, so we properly test against BusyBox
 # Things like tar/zip are needed by unarchive
 # diffutils is installed for runme.sh tests that call diff
-# coreutils was explicitly left out
+# coreutils was explicitly omitted
+# sshpass was explicitly omitted as BusyBox timeout causes issues with out connection_ssh tests
 RUN apk add --no-cache openrc \
         acl \
         apache2 \
@@ -36,7 +37,6 @@ RUN apk add --no-cache openrc \
         py3-wheel \
         ruby \
         rsync \
-        sshpass \
         subversion \
         sudo \
         tar \

--- a/alpine3-test-container/Dockerfile
+++ b/alpine3-test-container/Dockerfile
@@ -4,7 +4,7 @@ FROM alpine:3.12.0
 # Things like tar/zip are needed by unarchive
 # diffutils is installed for runme.sh tests that call diff
 # coreutils was explicitly omitted
-# sshpass was explicitly omitted as BusyBox timeout causes issues with out connection_ssh tests
+# sshpass was explicitly omitted as BusyBox timeout causes issues with our connection_ssh tests
 RUN apk add --no-cache openrc \
         acl \
         apache2 \


### PR DESCRIPTION
This PR removes sshpass from the alpine3 container. This ensures that problematic tests due to BusyBox timeout are excluded on alpine3, that are executed depending on `sshpass` being available.  This resolves the issues with ansible-test hanging in shippable.