### PR TITLE
Remove apt lists after package installations in ubuntu containers

### DIFF
--- a/ubuntu1604-test-container/Dockerfile
+++ b/ubuntu1604-test-container/Dockerfile
@@ -56,7 +56,9 @@ RUN apt-get update -y && \
     xsltproc \
     zip \
     && \
-    apt-get clean
+    apt-get clean \
+    && \
+    rm -rf /var/lib/apt/lists/*
 
 RUN rm /etc/apt/apt.conf.d/docker-clean
 RUN mkdir /etc/ansible/

--- a/ubuntu1804-test-container/Dockerfile
+++ b/ubuntu1804-test-container/Dockerfile
@@ -54,7 +54,9 @@ RUN apt-get update -y && \
     xsltproc \
     zip \
     && \
-    apt-get clean
+    apt-get clean \
+    && \
+    rm -rf /var/lib/apt/lists/*
 
 RUN ln -s /lib/systemd/systemd /sbin/init
 RUN rm /etc/apt/apt.conf.d/docker-clean

--- a/ubuntu2004-test-container/Dockerfile
+++ b/ubuntu2004-test-container/Dockerfile
@@ -54,7 +54,9 @@ RUN apt-get update -y && \
     xsltproc \
     zip \
     && \
-    apt-get clean
+    apt-get clean \
+    && \
+    rm -rf /var/lib/apt/lists/*
 
 RUN ln -s /lib/systemd/systemd /sbin/init
 RUN rm /etc/apt/apt.conf.d/docker-clean


### PR DESCRIPTION
https://docs.docker.com/develop/develop-images/dockerfile_best-practices/
> In addition, when you clean up the apt cache by removing /var/lib/apt/lists it reduces the image size, since the apt cache is not stored in a layer. Since the RUN statement starts with apt-get update, the package cache is always refreshed prior to apt-get install.
```
ubuntu16                         withlists               600MB
ubuntu16                         withoutlists            570MB
```