### PR TITLE
Add missing opensuse 15.2 deps that we need

### DIFF
--- a/opensuse15-test-container/Dockerfile
+++ b/opensuse15-test-container/Dockerfile
@@ -17,6 +17,7 @@ RUN zypper --non-interactive --gpg-auto-import-keys refresh --services --force &
     make \
     openssh \
     postgresql-server \
+    python3-cairo \
     python3-cryptography \
     python3-devel \
     python3-httplib2 \
@@ -29,6 +30,7 @@ RUN zypper --non-interactive --gpg-auto-import-keys refresh --services --force &
     python3-passlib \
     python3-pip \
     python3-psycopg2 \
+    python3-pycrypto \
     python3-PyYAML \
     python3-selinux \
     python3-setuptools \

--- a/opensuse15py2-test-container/Dockerfile
+++ b/opensuse15py2-test-container/Dockerfile
@@ -18,6 +18,7 @@ RUN zypper --non-interactive --gpg-auto-import-keys refresh --services --force &
     mercurial \
     openssh \
     postgresql-server \
+    python2-cairo \
     python-cryptography \
     python-devel \
     python-httplib2 \
@@ -30,6 +31,7 @@ RUN zypper --non-interactive --gpg-auto-import-keys refresh --services --force &
     python-passlib \
     python-pip \
     python-psycopg2 \
+    python2-pycrypto \
     python-PyYAML \
     python-setuptools \
     python-virtualenv \


### PR DESCRIPTION
We bring in python gobject and keyczar, but they have deps that are
seemingly not indicated in their opensuse packaging. Install those deps
so they work.

Signed-off-by: Rick Elrod <rick@elrod.me>