### PR TITLE
Fedora 33 container seemingly does not start ssh by default

### DIFF
--- a/fedora33-test-container/Dockerfile
+++ b/fedora33-test-container/Dockerfile
@@ -70,5 +70,6 @@ RUN ssh-keygen -q -t dsa -N '' -f /etc/ssh/ssh_host_dsa_key && \
     cp /root/.ssh/id_rsa.pub /root/.ssh/authorized_keys && \
     for key in /etc/ssh/ssh_host_*_key.pub; do echo "localhost $(cat ${key})" >> /root/.ssh/known_hosts; done
 RUN pip3 install 'coverage<5' junit-xml
+RUN systemctl enable sshd.service
 ENV container=docker
 CMD ["/usr/sbin/init"]


### PR DESCRIPTION
grumble.