### PR TITLE
[centos6] Update repo file, point to centos vault

### DIFF
--- a/centos6-test-container/Dockerfile
+++ b/centos6-test-container/Dockerfile
@@ -1,6 +1,9 @@
 FROM centos:6.10
 
-RUN yum clean all && \
+COPY centos610-vault.repo /etc/yum.repos.d/centos610-vault.repo
+
+RUN rm /etc/yum.repos.d/CentOS-Base.repo && \
+    yum clean all && \
     yum -y install epel-release && \
     yum -y install \
     acl \
@@ -42,7 +45,7 @@ RUN yum clean all && \
     rpm -e --nodeps python-crypto && \
     yum clean all
 
-RUN pip install --upgrade pycrypto 'cryptography<2.0.0' 'pycparser<2.19'
+RUN pip install --upgrade pycrypto 'cryptography<2.0.0' 'pycparser<2.19' 'cffi!=1.14.4'
 
 RUN /bin/sed -i -e 's/^\(Defaults\s*requiretty\)/#--- \1/'  /etc/sudoers
 RUN mkdir /etc/ansible/

--- a/centos6-test-container/centos610-vault.repo
+++ b/centos6-test-container/centos610-vault.repo
@@ -1,0 +1,34 @@
+[C6.10-base]
+name=CentOS-6.10 - Base
+baseurl=http://vault.centos.org/6.10/os/$basearch/ http://archive.kernel.org/centos-vault/6.10/os/$basearch/
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6
+enabled=1
+
+[C6.10-updates]
+name=CentOS-6.10 - Updates
+baseurl=http://vault.centos.org/6.10/updates/$basearch/ http://archive.kernel.org/centos-vault/6.10/updates/$basearch/
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6
+enabled=1
+
+[C6.10-extras]
+name=CentOS-6.10 - Extras
+baseurl=http://vault.centos.org/6.10/extras/$basearch/ http://archive.kernel.org/centos-vault/6.10/extras/$basearch/
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6
+enabled=1
+
+[C6.10-contrib]
+name=CentOS-6.10 - Contrib
+baseurl=http://vault.centos.org/6.10/contrib/$basearch/ http://archive.kernel.org/centos-vault/6.10/contrib/$basearch/
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6
+enabled=1
+
+[C6.10-centosplus]
+name=CentOS-6.10 - CentOSPlus
+baseurl=http://vault.centos.org/6.10/centosplus/$basearch/ http://archive.kernel.org/centos-vault/6.10/centosplus/$basearch/
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6
+enabled=1


### PR DESCRIPTION
Change:
- CentOS 6 is now EOL and the repos have moved to the centos vault.
- reference:
  https://lists.centos.org/pipermail/centos-devel/2020-December/056208.html
- Also add constraint around cffi so it builds on old gcc

Signed-off-by: Rick Elrod <rick@elrod.me>