### PR TITLE
[centos6] pin junit-xml to 1.8

### DIFF
--- a/centos6-test-container/Dockerfile
+++ b/centos6-test-container/Dockerfile
@@ -57,6 +57,6 @@ RUN ssh-keygen -q -t rsa1 -N '' -f /etc/ssh/ssh_host_key && \
     ssh-keygen -q -t rsa -N '' -f /root/.ssh/id_rsa && \
     cp /root/.ssh/id_rsa.pub /root/.ssh/authorized_keys && \
     for key in /etc/ssh/ssh_host_*_key.pub; do echo "localhost $(cat ${key})" >> /root/.ssh/known_hosts; done
-RUN pip install 'coverage<5' junit-xml 'packaging==16.8'
+RUN pip install 'coverage<5' 'junit-xml==1.8' 'packaging==16.8'
 ENV container=docker
 CMD ["/sbin/init"]


### PR DESCRIPTION
Change:
- This is to avoid a deprecation warning.

Signed-off-by: Rick Elrod <rick@elrod.me>