### PR TITLE
Use Quay for base images

### DIFF
--- a/alpine3-test-container/Dockerfile
+++ b/alpine3-test-container/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.12.0
+FROM quay.io/bedrock/alpine:3.12.0
 
 # Keep this as basic as possible, so we properly test against BusyBox
 # Things like tar/zip are needed by unarchive

--- a/centos6-test-container/Dockerfile
+++ b/centos6-test-container/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:6.10
+FROM quay.io/bedrock/centos:6.10
 
 COPY centos610-vault.repo /etc/yum.repos.d/centos610-vault.repo
 

--- a/centos7-test-container/Dockerfile
+++ b/centos7-test-container/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:7.8.2003
+FROM quay.io/bedrock/centos:7.8.2003
 
 RUN (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i == systemd-tmpfiles-setup.service ] || rm -f $i; done); \
 rm -f /lib/systemd/system/multi-user.target.wants/*; \

--- a/centos8-test-container/Dockerfile
+++ b/centos8-test-container/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:8.2.2004
+FROM quay.io/bedrock/centos:8.2.2004
 
 ENV KEEPLANG="en_US.utf8"
 

--- a/fedora30-test-container/Dockerfile
+++ b/fedora30-test-container/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:30
+FROM quay.io/bedrock/fedora:30
 
 RUN (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i == systemd-tmpfiles-setup.service ] || rm -f $i; done); \
 rm -f /lib/systemd/system/multi-user.target.wants/*; \

--- a/fedora31-test-container/Dockerfile
+++ b/fedora31-test-container/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:31
+FROM quay.io/bedrock/fedora:31
 
 RUN dnf clean all && \
     dnf -y upgrade && \

--- a/fedora32-test-container/Dockerfile
+++ b/fedora32-test-container/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:32
+FROM quay.io/bedrock/fedora:32
 
 
 RUN dnf clean all && \

--- a/fedora33-test-container/Dockerfile
+++ b/fedora33-test-container/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:33
+FROM quay.io/bedrock/fedora:33
 
 
 RUN dnf clean all && \

--- a/opensuse15-test-container/Dockerfile
+++ b/opensuse15-test-container/Dockerfile
@@ -1,4 +1,4 @@
-FROM opensuse/leap:15.2
+FROM quay.io/bedrock/leap:15.2
 
 RUN zypper --non-interactive --gpg-auto-import-keys refresh --services --force && \
     zypper --non-interactive install --force systemd-sysvinit && \

--- a/opensuse15py2-test-container/Dockerfile
+++ b/opensuse15py2-test-container/Dockerfile
@@ -1,4 +1,4 @@
-FROM opensuse/leap:15.2
+FROM quay.io/bedrock/leap:15.2
 
 RUN zypper --non-interactive --gpg-auto-import-keys refresh --services --force && \
     zypper --non-interactive install --force systemd-sysvinit && \

--- a/ubuntu1604-test-container/Dockerfile
+++ b/ubuntu1604-test-container/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM quay.io/bedrock/ubuntu:16.04
 
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \

--- a/ubuntu1604-test-container/Dockerfile
+++ b/ubuntu1604-test-container/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/bedrock/ubuntu:16.04
+FROM quay.io/bedrock/ubuntu:xenial-20201030
 
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \

--- a/ubuntu1804-test-container/Dockerfile
+++ b/ubuntu1804-test-container/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:bionic-20181018
+FROM quay.io/bedrock/ubuntu:bionic-20181018
 
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \

--- a/ubuntu2004-test-container/Dockerfile
+++ b/ubuntu2004-test-container/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:focal-20200423
+FROM quay.io/bedrock/ubuntu:focal-20200423
 
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \


### PR DESCRIPTION
Due to the new Docker Hub anonymous pull limits, use base images hosted in Quay.