### PR TITLE
Remove mercurial from containers.

### DIFF
--- a/alpine3-test-container/Dockerfile
+++ b/alpine3-test-container/Dockerfile
@@ -17,7 +17,6 @@ RUN apk add --no-cache openrc \
         git \
         libffi-dev \
         make \
-        mercurial \
         openssh-client \
         openssh-server \
         openssh-sftp-server \

--- a/centos6-test-container/Dockerfile
+++ b/centos6-test-container/Dockerfile
@@ -15,7 +15,6 @@ RUN rm /etc/yum.repos.d/CentOS-Base.repo && \
     libffi \
     libffi-devel \
     make \
-    mercurial \
     openssh-clients \
     openssh-server \
     openssl-devel \

--- a/centos7-test-container/Dockerfile
+++ b/centos7-test-container/Dockerfile
@@ -23,7 +23,6 @@ RUN yum clean all && \
     libffi \
     libffi-devel \
     make \
-    mercurial \
     openssh-clients \
     openssh-server \
     openssl-devel \

--- a/centos8-test-container/Dockerfile
+++ b/centos8-test-container/Dockerfile
@@ -31,7 +31,6 @@ RUN dnf clean all && \
     libffi-devel \
     libuser \
     make \
-    mercurial \
     openssh-clients \
     openssh-server \
     openssl-devel \

--- a/opensuse15py2-test-container/Dockerfile
+++ b/opensuse15py2-test-container/Dockerfile
@@ -15,7 +15,6 @@ RUN zypper --non-interactive --gpg-auto-import-keys refresh --services --force &
     iproute2 \
     lsb-release \
     make \
-    mercurial \
     openssh \
     postgresql-server \
     python2-cairo \

--- a/ubuntu1604-test-container/Dockerfile
+++ b/ubuntu1604-test-container/Dockerfile
@@ -24,7 +24,6 @@ RUN apt-get update -y && \
     locales \
     lsb-release \
     make \
-    mercurial \
     openssh-client \
     openssh-server \
     python-cryptography \


### PR DESCRIPTION
It should only be used by the `hg` integration tests, which should be handling install/uninstall of mercurial.

This reduces container size and eliminates Python 2 on the centos8 container.