### PR TITLE
[opensuse15] Replace ensurepip-vendored setuptools

### DIFF
--- a/opensuse15-test-container/Dockerfile
+++ b/opensuse15-test-container/Dockerfile
@@ -71,5 +71,8 @@ RUN ssh-keygen -q -t dsa -N '' -f /etc/ssh/ssh_host_dsa_key && \
 # explicitly enable the service, opensuse default to disabled services
 RUN systemctl enable sshd.service
 RUN pip install 'coverage==4.5.4' 'resolvelib==0.5.4' 'junit-xml==1.9'
+# 15.2 ships with a broken ensurepip, we need to replace this .whl
+ADD https://ansible-ci-files.s3.amazonaws.com/distro-test-container-files/setuptools-44.1.1-py2.py3-none-any.whl \
+  /usr/lib64/python3.6/ensurepip/_bundled/setuptools-44.1.1-py2.py3-none-any.whl
 ENV container=docker
 CMD ["/sbin/init"]


### PR DESCRIPTION
Change:
- The ensurepip setuptools that comes with opensuse 15.2's python3-base
  package rewrites imports for vendored libs which causes them to not be
  importable. Replace the broken wheel with the wheel from pypi.

Test Plan:
- `pip3 install 'jinja2 >= 2.6, < 2.7'7'` in a venv in container.

Signed-off-by: Rick Elrod <rick@elrod.me>