### PR TITLE
[centos6] Add several more CentOS Vault mirrors

### DIFF
--- a/centos6-test-container/centos610-vault.repo
+++ b/centos6-test-container/centos610-vault.repo
@@ -1,34 +1,54 @@
 [C6.10-base]
 name=CentOS-6.10 - Base
-baseurl=http://vault.centos.org/6.10/os/$basearch/ http://archive.kernel.org/centos-vault/6.10/os/$basearch/
+baseurl=
+    https://vault.centos.org/6.10/os/$basearch/
+    http://vault.centos.org/6.10/os/$basearch/
+    http://mirror.rackspace.com/centos-vault/6.10/os/$basearch/
+    https://anorien.csc.warwick.ac.uk/mirrors/CentOS-vault/6.10/os/$basearch/
 gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6
 enabled=1
 
 [C6.10-updates]
 name=CentOS-6.10 - Updates
-baseurl=http://vault.centos.org/6.10/updates/$basearch/ http://archive.kernel.org/centos-vault/6.10/updates/$basearch/
+baseurl=
+    https://vault.centos.org/6.10/updates/$basearch/
+    http://vault.centos.org/6.10/updates/$basearch/
+    http://mirror.rackspace.com/centos-vault/6.10/updates/$basearch/
+    https://anorien.csc.warwick.ac.uk/mirrors/CentOS-vault/6.10/updates/$basearch/
 gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6
 enabled=1
 
 [C6.10-extras]
 name=CentOS-6.10 - Extras
-baseurl=http://vault.centos.org/6.10/extras/$basearch/ http://archive.kernel.org/centos-vault/6.10/extras/$basearch/
+baseurl=
+    https://vault.centos.org/6.10/extras/$basearch/
+    http://vault.centos.org/6.10/extras/$basearch/
+    http://mirror.rackspace.com/centos-vault/6.10/extras/$basearch/
+    https://anorien.csc.warwick.ac.uk/mirrors/CentOS-vault/6.10/extras/$basearch/
 gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6
 enabled=1
 
 [C6.10-contrib]
 name=CentOS-6.10 - Contrib
-baseurl=http://vault.centos.org/6.10/contrib/$basearch/ http://archive.kernel.org/centos-vault/6.10/contrib/$basearch/
+baseurl=
+    https://vault.centos.org/6.10/contrib/$basearch/
+    http://vault.centos.org/6.10/contrib/$basearch/
+    http://mirror.rackspace.com/centos-vault/6.10/contrib/$basearch/
+    https://anorien.csc.warwick.ac.uk/mirrors/CentOS-vault/6.10/contrib/$basearch/
 gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6
 enabled=1
 
 [C6.10-centosplus]
 name=CentOS-6.10 - CentOSPlus
-baseurl=http://vault.centos.org/6.10/centosplus/$basearch/ http://archive.kernel.org/centos-vault/6.10/centosplus/$basearch/
+baseurl=
+    https://vault.centos.org/6.10/centosplus/$basearch/
+    http://vault.centos.org/6.10/centosplus/$basearch/
+    http://mirror.rackspace.com/centos-vault/6.10/centosplus/$basearch/
+    https://anorien.csc.warwick.ac.uk/mirrors/CentOS-vault/6.10/centosplus/$basearch/
 gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6
 enabled=1


### PR DESCRIPTION
Change:
- Eliminate vault.centos.org SPOF
- Add several public mirrors that also mirror Vault content
- Nuke kernel.org mirror which was very out of date

Test Plan:
- local build

Signed-off-by: Rick Elrod <rick@elrod.me>