### PR TITLE
Bump CentOS 8.3.2011

### DIFF
--- a/centos8-test-container/Dockerfile
+++ b/centos8-test-container/Dockerfile
@@ -17,7 +17,7 @@ RUN dnf clean all && \
     # Simply running dnf -y --allowerasing install coreutils resulted in a corrupt rpmdb
     rpm -e --nodeps coreutils-single && \
     dnf -y install epel-release && \
-    dnf -y --setopt=install_weak_deps=false --enablerepo=PowerTools install \
+    dnf -y --setopt=install_weak_deps=false --enablerepo=powertools install \
     acl \
     asciidoc \
     coreutils \

--- a/centos8-test-container/Dockerfile
+++ b/centos8-test-container/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/bedrock/centos:8.2.2004
+FROM quay.io/bedrock/centos:8.3.2011
 
 ENV KEEPLANG="en_US.utf8"
 


### PR DESCRIPTION
I have opened https://github.com/ansible/ansible/pull/73821 and this is failing on RHEL 8.3, but not on CentOS 8.2, I think this is because of this commit (https://git.centos.org/rpms/shadow-utils/c/5b8176e4435e0c661d8195c8dc9a1a5149c0c6c2?branch=c8) which has added `HOME_MODE 0700`.

Other than that it's three months since centos 8.3 has been released, so I guess this is an appropriate time to update the base image.

To make myself clear, I've opened this pull request so that I can be sure it also fails on CentOS 8 as well.