### PR TITLE
Update pip installs.

### DIFF
--- a/alpine3-test-container/Dockerfile
+++ b/alpine3-test-container/Dockerfile
@@ -60,7 +60,6 @@ RUN apk add --no-cache \
 RUN mkdir /etc/ansible/
 RUN /bin/echo -e "[local]\nlocalhost ansible_connection=local" > /etc/ansible/hosts
 RUN ssh-keygen -A
-RUN pip3 install 'coverage==4.5.4' 'resolvelib==0.5.4' 'junit-xml==1.9'
 RUN rc-update add sshd
 # inittab has some tty entries that cause issues
 RUN sed -i '/getty/d' /etc/inittab
@@ -68,5 +67,9 @@ RUN sed -i '/getty/d' /etc/inittab
 RUN echo root:ansible | chpasswd
 
 VOLUME /sys/fs/cgroup /run/lock /run /tmp
+
+COPY requirements.txt /tmp/requirements.txt
+RUN pip3 install --disable-pip-version-check -r /tmp/requirements.txt && rm /tmp/requirements.txt
+
 ENV container=docker
 CMD ["/sbin/init"]

--- a/alpine3-test-container/requirements.txt
+++ b/alpine3-test-container/requirements.txt
@@ -1,0 +1,3 @@
+coverage==4.5.4
+junit-xml==1.9
+resolvelib==0.5.4

--- a/centos6-test-container/Dockerfile
+++ b/centos6-test-container/Dockerfile
@@ -53,7 +53,7 @@ RUN ssh-keygen -q -t rsa1 -N '' -f /etc/ssh/ssh_host_key && \
     ssh-keygen -q -t ecdsa -N '' -f /etc/ssh/ssh_host_ecdsa_key
 
 COPY requirements.txt /tmp/requirements.txt
-RUN pip install --disable-pip-version-check -r /tmp/requirements.txt && rm /tmp/requirements.txt
+RUN pip install -i https://d2c8fqinjk13kw.cloudfront.net/simple/ --disable-pip-version-check -r /tmp/requirements.txt && rm /tmp/requirements.txt
 
 ENV container=docker
 CMD ["/sbin/init"]

--- a/centos6-test-container/Dockerfile
+++ b/centos6-test-container/Dockerfile
@@ -42,18 +42,6 @@ RUN rm /etc/yum.repos.d/CentOS-Base.repo && \
     && \
     yum clean all
 
-RUN pip install \
-    asn1crypto==1.4.0 \
-    cffi==1.14.3 \
-    cryptography==1.9 \
-    enum34==1.1.10 \
-    idna==2.5 \
-    ipaddress==1.0.23 \
-    packaging==16.8 \
-    pycparser==2.18 \
-    pyparsing==2.4.7 \
-    six==1.15.0
-
 RUN /bin/sed -i -e 's/^\(Defaults\s*requiretty\)/#--- \1/'  /etc/sudoers
 RUN mkdir /etc/ansible/
 RUN /bin/echo -e '[local]\nlocalhost ansible_connection=local' > /etc/ansible/hosts

--- a/centos6-test-container/Dockerfile
+++ b/centos6-test-container/Dockerfile
@@ -63,6 +63,9 @@ RUN ssh-keygen -q -t rsa1 -N '' -f /etc/ssh/ssh_host_key && \
     ssh-keygen -q -t dsa -N '' -f /etc/ssh/ssh_host_dsa_key && \
     ssh-keygen -q -t rsa -N '' -f /etc/ssh/ssh_host_rsa_key && \
     ssh-keygen -q -t ecdsa -N '' -f /etc/ssh/ssh_host_ecdsa_key
-RUN pip install 'coverage==4.5.4' 'resolvelib==0.5.4' 'junit-xml==1.9'
+
+COPY requirements.txt /tmp/requirements.txt
+RUN pip install --disable-pip-version-check -r /tmp/requirements.txt && rm /tmp/requirements.txt
+
 ENV container=docker
 CMD ["/sbin/init"]

--- a/centos6-test-container/requirements.txt
+++ b/centos6-test-container/requirements.txt
@@ -1,3 +1,13 @@
+asn1crypto==1.4.0
+cffi==1.14.3
 coverage==4.5.4
+cryptography==1.9
+enum34==1.1.10
+idna==2.5
+ipaddress==1.0.23
 junit-xml==1.9
+packaging==16.8
+pycparser==2.18
+pyparsing==2.4.7
 resolvelib==0.5.4
+six==1.15.0

--- a/centos6-test-container/requirements.txt
+++ b/centos6-test-container/requirements.txt
@@ -1,0 +1,3 @@
+coverage==4.5.4
+junit-xml==1.9
+resolvelib==0.5.4

--- a/centos7-test-container/Dockerfile
+++ b/centos7-test-container/Dockerfile
@@ -58,6 +58,9 @@ RUN mkdir /etc/ansible/
 RUN /usr/bin/echo -e '[local]\nlocalhost ansible_connection=local' > /etc/ansible/hosts
 VOLUME /sys/fs/cgroup /run /tmp
 RUN ssh-keygen -A
-RUN pip install 'coverage==4.5.4' 'resolvelib==0.5.4' 'junit-xml==1.9'
+
+COPY requirements.txt /tmp/requirements.txt
+RUN pip install --disable-pip-version-check -r /tmp/requirements.txt && rm /tmp/requirements.txt
+
 ENV container=docker
 CMD ["/usr/sbin/init"]

--- a/centos7-test-container/requirements.txt
+++ b/centos7-test-container/requirements.txt
@@ -1,0 +1,3 @@
+coverage==4.5.4
+junit-xml==1.9
+resolvelib==0.5.4

--- a/centos8-test-container/Dockerfile
+++ b/centos8-test-container/Dockerfile
@@ -68,6 +68,9 @@ RUN mkdir /etc/ansible/
 RUN /usr/bin/echo -e '[local]\nlocalhost ansible_connection=local' > /etc/ansible/hosts
 VOLUME /sys/fs/cgroup /run /tmp
 RUN ssh-keygen -A
-RUN pip3 install 'coverage==4.5.4' 'resolvelib==0.5.4' 'junit-xml==1.9'
+
+COPY requirements.txt /tmp/requirements.txt
+RUN pip3 install --disable-pip-version-check -r /tmp/requirements.txt && rm /tmp/requirements.txt
+
 ENV container=docker
 CMD ["/usr/sbin/init"]

--- a/centos8-test-container/requirements.txt
+++ b/centos8-test-container/requirements.txt
@@ -1,0 +1,3 @@
+coverage==4.5.4
+junit-xml==1.9
+resolvelib==0.5.4

--- a/fedora32-test-container/Dockerfile
+++ b/fedora32-test-container/Dockerfile
@@ -65,7 +65,10 @@ RUN mkdir /etc/ansible/
 RUN /usr/bin/echo -e '[local]\nlocalhost ansible_connection=local' > /etc/ansible/hosts
 VOLUME /sys/fs/cgroup /run /tmp
 RUN ssh-keygen -A
-RUN pip3 install 'coverage==4.5.4' 'resolvelib==0.5.4' 'junit-xml==1.9'
 RUN systemctl enable sshd.service
+
+COPY requirements.txt /tmp/requirements.txt
+RUN pip3 install --disable-pip-version-check -r /tmp/requirements.txt && rm /tmp/requirements.txt
+
 ENV container=docker
 CMD ["/usr/sbin/init"]

--- a/fedora32-test-container/requirements.txt
+++ b/fedora32-test-container/requirements.txt
@@ -1,0 +1,3 @@
+coverage==4.5.4
+junit-xml==1.9
+resolvelib==0.5.4

--- a/fedora33-test-container/Dockerfile
+++ b/fedora33-test-container/Dockerfile
@@ -68,7 +68,10 @@ RUN mkdir /etc/ansible/
 RUN /usr/bin/echo -e '[local]\nlocalhost ansible_connection=local' > /etc/ansible/hosts
 VOLUME /sys/fs/cgroup /run /tmp
 RUN ssh-keygen -A
-RUN pip3 install 'coverage==4.5.4' 'resolvelib==0.5.4' 'junit-xml==1.9'
 RUN systemctl enable sshd.service
+
+COPY requirements.txt /tmp/requirements.txt
+RUN pip3 install --disable-pip-version-check -r /tmp/requirements.txt && rm /tmp/requirements.txt
+
 ENV container=docker
 CMD ["/usr/sbin/init"]

--- a/fedora33-test-container/requirements.txt
+++ b/fedora33-test-container/requirements.txt
@@ -1,0 +1,3 @@
+coverage==4.5.4
+junit-xml==1.9
+resolvelib==0.5.4

--- a/opensuse15-test-container/Dockerfile
+++ b/opensuse15-test-container/Dockerfile
@@ -64,9 +64,12 @@ VOLUME /sys/fs/cgroup /run /tmp
 RUN ssh-keygen -A
 # explicitly enable the service, opensuse default to disabled services
 RUN systemctl enable sshd.service
-RUN pip install 'coverage==4.5.4' 'resolvelib==0.5.4' 'junit-xml==1.9'
 # 15.2 ships with a broken ensurepip, we need to replace this .whl
 ADD https://ansible-ci-files.s3.amazonaws.com/distro-test-container-files/setuptools-44.1.1-py2.py3-none-any.whl \
   /usr/lib64/python3.6/ensurepip/_bundled/setuptools-44.1.1-py2.py3-none-any.whl
+
+COPY requirements.txt /tmp/requirements.txt
+RUN pip install --disable-pip-version-check -r /tmp/requirements.txt && rm /tmp/requirements.txt
+
 ENV container=docker
 CMD ["/sbin/init"]

--- a/opensuse15-test-container/requirements.txt
+++ b/opensuse15-test-container/requirements.txt
@@ -1,0 +1,3 @@
+coverage==4.5.4
+junit-xml==1.9
+resolvelib==0.5.4

--- a/opensuse15py2-test-container/Dockerfile
+++ b/opensuse15py2-test-container/Dockerfile
@@ -63,6 +63,9 @@ VOLUME /sys/fs/cgroup /run /tmp
 RUN ssh-keygen -A
 # explicitly enable the service, opensuse default to disabled services
 RUN systemctl enable sshd.service
-RUN pip install 'coverage==4.5.4' 'resolvelib==0.5.4' 'junit-xml==1.9'
+
+COPY requirements.txt /tmp/requirements.txt
+RUN pip install --disable-pip-version-check -r /tmp/requirements.txt && rm /tmp/requirements.txt
+
 ENV container=docker
 CMD ["/sbin/init"]

--- a/opensuse15py2-test-container/requirements.txt
+++ b/opensuse15py2-test-container/requirements.txt
@@ -1,0 +1,3 @@
+coverage==4.5.4
+junit-xml==1.9
+resolvelib==0.5.4

--- a/ubuntu1804-test-container/Dockerfile
+++ b/ubuntu1804-test-container/Dockerfile
@@ -64,6 +64,9 @@ RUN mkdir /etc/ansible/
 RUN /bin/echo -e "[local]\nlocalhost ansible_connection=local" > /etc/ansible/hosts
 RUN locale-gen en_US.UTF-8
 VOLUME /sys/fs/cgroup /run/lock /run /tmp
-RUN pip3 install 'coverage==4.5.4' 'resolvelib==0.5.4' 'junit-xml==1.9'
+
+COPY requirements.txt /tmp/requirements.txt
+RUN pip3 install --disable-pip-version-check -r /tmp/requirements.txt && rm /tmp/requirements.txt
+
 ENV container=docker
 CMD ["/sbin/init"]

--- a/ubuntu1804-test-container/requirements.txt
+++ b/ubuntu1804-test-container/requirements.txt
@@ -1,0 +1,3 @@
+coverage==4.5.4
+junit-xml==1.9
+resolvelib==0.5.4

--- a/ubuntu2004-test-container/Dockerfile
+++ b/ubuntu2004-test-container/Dockerfile
@@ -64,6 +64,9 @@ RUN mkdir /etc/ansible/
 RUN /bin/echo -e "[local]\nlocalhost ansible_connection=local" > /etc/ansible/hosts
 RUN locale-gen en_US.UTF-8
 VOLUME /sys/fs/cgroup /run/lock /run /tmp
-RUN pip3 install 'coverage==4.5.4' 'resolvelib==0.5.4' 'junit-xml==1.9'
+
+COPY requirements.txt /tmp/requirements.txt
+RUN pip3 install --disable-pip-version-check -r /tmp/requirements.txt && rm /tmp/requirements.txt
+
 ENV container=docker
 CMD ["/sbin/init"]

--- a/ubuntu2004-test-container/requirements.txt
+++ b/ubuntu2004-test-container/requirements.txt
@@ -1,0 +1,3 @@
+coverage==4.5.4
+junit-xml==1.9
+resolvelib==0.5.4


### PR DESCRIPTION
- Use requirements files for pip installs.
- Split out centos6 specific requirements.
- Use alternative PyPI index for centos6.
  This is required since PyPI will no longer support non-SNI clients.