### PR TITLE
Use six 1.13.0 for centos6.

### DIFF
--- a/centos6-test-container/requirements.txt
+++ b/centos6-test-container/requirements.txt
@@ -10,4 +10,4 @@ packaging==16.8
 pycparser==2.18
 pyparsing==2.4.7
 resolvelib==0.5.4
-six==1.15.0
+six==1.13.0


### PR DESCRIPTION
The currently installed version, 1.15.0, does not support Python 2.6.