### PR TITLE
Fix up fedora containers and add f34

### DIFF
--- a/fedora32-test-container/Dockerfile
+++ b/fedora32-test-container/Dockerfile
@@ -51,7 +51,7 @@ RUN dnf clean all && \
     dnf clean all
 
 RUN (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i == systemd-tmpfiles-setup.service ] || rm -f $i; done); \
-    rm -f /lib/systemd/system/multi-user.target.wants/*; \
+    (cd /lib/systemd/system/multi-user.target.wants/; for i in *; do [ $i == systemd-user-sessions.service ] || rm -f $i; done); \
     rm -f /etc/systemd/system/*.wants/*; \
     rm -f /lib/systemd/system/local-fs.target.wants/*; \
     rm -f /lib/systemd/system/sockets.target.wants/*udev*; \
@@ -61,6 +61,10 @@ RUN (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i == system
 
 RUN localedef --quiet -c -i en_US -f UTF-8 en_US.UTF-8
 RUN /usr/bin/sed -i -e 's/^\(Defaults\s*requiretty\)/#--- \1/'  /etc/sudoers
+# pam_loginuid wants to write to /proc/self/loginuid on new ssh session, but can't.
+# https://github.com/lxc/lxc/issues/661#issuecomment-222444916
+# https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=726661
+RUN /usr/bin/sed -i -e '/pam_loginuid\.so$/ s/required/optional/' /etc/pam.d/*
 RUN mkdir /etc/ansible/
 RUN /usr/bin/echo -e '[local]\nlocalhost ansible_connection=local' > /etc/ansible/hosts
 VOLUME /sys/fs/cgroup /run /tmp

--- a/fedora33-test-container/Dockerfile
+++ b/fedora33-test-container/Dockerfile
@@ -51,7 +51,7 @@ RUN dnf clean all && \
     dnf clean all
 
 RUN (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i == systemd-tmpfiles-setup.service ] || rm -f $i; done); \
-    rm -f /lib/systemd/system/multi-user.target.wants/*; \
+    (cd /lib/systemd/system/multi-user.target.wants/; for i in *; do [ $i == systemd-user-sessions.service ] || rm -f $i; done); \
     rm -f /etc/systemd/system/*.wants/*; \
     rm -f /lib/systemd/system/local-fs.target.wants/*; \
     rm -f /lib/systemd/system/sockets.target.wants/*udev*; \
@@ -61,6 +61,10 @@ RUN (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i == system
 
 RUN localedef --quiet -c -i en_US -f UTF-8 en_US.UTF-8
 RUN /usr/bin/sed -i -e 's/^\(Defaults\s*requiretty\)/#--- \1/'  /etc/sudoers
+# pam_loginuid wants to write to /proc/self/loginuid on new ssh session, but can't.
+# https://github.com/lxc/lxc/issues/661#issuecomment-222444916
+# https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=726661
+RUN /usr/bin/sed -i -e '/pam_loginuid\.so$/ s/required/optional/' /etc/pam.d/*
 # allow ssh-rsa key authentication, which is required for paramiko and EC2 compatibility
 RUN /usr/bin/sed -i -e 's/^PubkeyAcceptedKeyTypes /PubkeyAcceptedKeyTypes ssh-rsa,/' /usr/share/crypto-policies/DEFAULT/openssh.txt
 RUN /usr/bin/sed -i -e 's/^PubkeyAcceptedKeyTypes /PubkeyAcceptedKeyTypes ssh-rsa,/' /usr/share/crypto-policies/DEFAULT/opensshserver.txt

--- a/fedora34-test-container/Dockerfile
+++ b/fedora34-test-container/Dockerfile
@@ -1,0 +1,81 @@
+FROM quay.io/bedrock/fedora:34
+
+
+RUN dnf clean all && \
+    dnf -y upgrade && \
+    dnf -y --allowerasing install coreutils && \
+    dnf -y --setopt=install_weak_deps=false install \
+    acl \
+    bzip2 \
+    file \
+    findutils \
+    gcc \
+    git \
+    glibc-locale-source \
+    iproute \
+    libffi \
+    libffi-devel \
+    make \
+    openssh-clients \
+    openssh-server \
+    openssl-devel \
+    pass \
+    procps \
+    python3-cryptography \
+    python3-dbus \
+    python3-devel \
+    python3-dnf \
+    python3-httplib2 \
+    python3-jinja2 \
+    python3-lxml \
+    python3-mock \
+    python3-nose \
+    python3-packaging \
+    python3-passlib \
+    python3-pip \
+    python3-PyYAML \
+    python3-setuptools \
+    python3-virtualenv \
+    rpm-build \
+    rubygems \
+    rubygem-rdoc \
+    sshpass \
+    subversion \
+    sudo \
+    systemd \
+    tar \
+    unzip \
+    which \
+    zip \
+    && \
+    dnf clean all
+
+RUN (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i == systemd-tmpfiles-setup.service ] || rm -f $i; done); \
+    (cd /lib/systemd/system/multi-user.target.wants/; for i in *; do [ $i == systemd-user-sessions.service ] || rm -f $i; done); \
+    rm -f /etc/systemd/system/*.wants/*; \
+    rm -f /lib/systemd/system/local-fs.target.wants/*; \
+    rm -f /lib/systemd/system/sockets.target.wants/*udev*; \
+    rm -f /lib/systemd/system/sockets.target.wants/*initctl*; \
+    rm -f /lib/systemd/system/basic.target.wants/*; \
+    rm -f /lib/systemd/system/anaconda.target.wants/*;
+
+RUN localedef --quiet -c -i en_US -f UTF-8 en_US.UTF-8
+RUN /usr/bin/sed -i -e 's/^\(Defaults\s*requiretty\)/#--- \1/'  /etc/sudoers
+# pam_loginuid wants to write to /proc/self/loginuid on new ssh session, but can't.
+# https://github.com/lxc/lxc/issues/661#issuecomment-222444916
+# https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=726661
+RUN /usr/bin/sed -i -e '/pam_loginuid\.so$/ s/required/optional/' /etc/pam.d/*
+# allow ssh-rsa key authentication, which is required for paramiko and EC2 compatibility
+RUN /usr/bin/sed -i -e 's/^PubkeyAcceptedKeyTypes /PubkeyAcceptedKeyTypes ssh-rsa,/' /usr/share/crypto-policies/DEFAULT/openssh.txt
+RUN /usr/bin/sed -i -e 's/^PubkeyAcceptedKeyTypes /PubkeyAcceptedKeyTypes ssh-rsa,/' /usr/share/crypto-policies/DEFAULT/opensshserver.txt
+RUN mkdir /etc/ansible/
+RUN /usr/bin/echo -e '[local]\nlocalhost ansible_connection=local' > /etc/ansible/hosts
+VOLUME /sys/fs/cgroup /run /tmp
+RUN ssh-keygen -A
+RUN systemctl enable sshd.service
+
+COPY requirements.txt /tmp/requirements.txt
+RUN pip3 install --disable-pip-version-check -r /tmp/requirements.txt && rm /tmp/requirements.txt
+
+ENV container=docker
+CMD ["/usr/sbin/init"]

--- a/fedora34-test-container/requirements.txt
+++ b/fedora34-test-container/requirements.txt
@@ -1,0 +1,3 @@
+coverage==4.5.4
+junit-xml==1.9
+resolvelib==0.5.4


### PR DESCRIPTION
NOTE: rebase this PR, don't squash.

commit 1878f2fa4e4f534e61c0e96228ef255a29ea9fcb (HEAD -> fedorafixes, relrod/fedorafixes)
Author: Rick Elrod <rick@elrod.me>
Date:   Thu Apr 29 15:27:24 2021 -0500

    [fedora34] Add new Dockerfile
    
    Change:
    - Fedora 34 is out, add new dockerfile for it.
    - Note that this needs to run with seccomp=unconfined due to systemd
      making use of new syscalls and them not being in the seccomp profile.
    
    Test Plan:
    - Tested locally against all test groups and got passes.
    
    Signed-off-by: Rick Elrod <rick@elrod.me>

--------

commit 74395dbc1fce1ad6a26d6e1c5db07cc60283573f
Author: Rick Elrod <rick@elrod.me>
Date:   Thu Apr 29 14:19:26 2021 -0500

    [fedora] some fixes for sshing into fedora
    
    Change:
    - Stop removing a service file so that /var/run/nologin gets removed.
    - Ensure pam_loginuid isn't required, because /proc/self/loginuid isn't
      writable in many container environments.
    
    Test Plan:
    - Lots of local experimentation
    
    Signed-off-by: Rick Elrod <rick@elrod.me>

