### PR TITLE
chore: Use --no-cache-dir flag to pip in Dockerfiles, to save space

### DIFF
--- a/alpine3-test-container/Dockerfile
+++ b/alpine3-test-container/Dockerfile
@@ -69,7 +69,7 @@ RUN echo root:ansible | chpasswd
 VOLUME /sys/fs/cgroup /run/lock /run /tmp
 
 COPY requirements.txt /tmp/requirements.txt
-RUN pip3 install --disable-pip-version-check -r /tmp/requirements.txt && rm /tmp/requirements.txt
+RUN pip3 install --no-cache-dir --disable-pip-version-check -r /tmp/requirements.txt && rm /tmp/requirements.txt
 
 ENV container=docker
 CMD ["/sbin/init"]

--- a/centos6-test-container/Dockerfile
+++ b/centos6-test-container/Dockerfile
@@ -53,7 +53,7 @@ RUN ssh-keygen -q -t rsa1 -N '' -f /etc/ssh/ssh_host_key && \
     ssh-keygen -q -t ecdsa -N '' -f /etc/ssh/ssh_host_ecdsa_key
 
 COPY requirements.txt /tmp/requirements.txt
-RUN pip install -i https://d2c8fqinjk13kw.cloudfront.net/simple/ --disable-pip-version-check -r /tmp/requirements.txt && rm /tmp/requirements.txt
+RUN pip install --no-cache-dir -i https://d2c8fqinjk13kw.cloudfront.net/simple/ --disable-pip-version-check -r /tmp/requirements.txt && rm /tmp/requirements.txt
 
 ENV container=docker
 CMD ["/sbin/init"]

--- a/centos7-test-container/Dockerfile
+++ b/centos7-test-container/Dockerfile
@@ -60,7 +60,7 @@ VOLUME /sys/fs/cgroup /run /tmp
 RUN ssh-keygen -A
 
 COPY requirements.txt /tmp/requirements.txt
-RUN pip install --disable-pip-version-check -r /tmp/requirements.txt && rm /tmp/requirements.txt
+RUN pip install --no-cache-dir --disable-pip-version-check -r /tmp/requirements.txt && rm /tmp/requirements.txt
 
 ENV container=docker
 CMD ["/usr/sbin/init"]

--- a/centos8-test-container/Dockerfile
+++ b/centos8-test-container/Dockerfile
@@ -70,7 +70,7 @@ VOLUME /sys/fs/cgroup /run /tmp
 RUN ssh-keygen -A
 
 COPY requirements.txt /tmp/requirements.txt
-RUN pip3 install --disable-pip-version-check -r /tmp/requirements.txt && rm /tmp/requirements.txt
+RUN pip3 install --no-cache-dir --disable-pip-version-check -r /tmp/requirements.txt && rm /tmp/requirements.txt
 
 ENV container=docker
 CMD ["/usr/sbin/init"]

--- a/fedora32-test-container/Dockerfile
+++ b/fedora32-test-container/Dockerfile
@@ -72,7 +72,7 @@ RUN ssh-keygen -A
 RUN systemctl enable sshd.service
 
 COPY requirements.txt /tmp/requirements.txt
-RUN pip3 install --disable-pip-version-check -r /tmp/requirements.txt && rm /tmp/requirements.txt
+RUN pip3 install --no-cache-dir --disable-pip-version-check -r /tmp/requirements.txt && rm /tmp/requirements.txt
 
 ENV container=docker
 CMD ["/usr/sbin/init"]

--- a/fedora33-test-container/Dockerfile
+++ b/fedora33-test-container/Dockerfile
@@ -75,7 +75,7 @@ RUN ssh-keygen -A
 RUN systemctl enable sshd.service
 
 COPY requirements.txt /tmp/requirements.txt
-RUN pip3 install --disable-pip-version-check -r /tmp/requirements.txt && rm /tmp/requirements.txt
+RUN pip3 install --no-cache-dir --disable-pip-version-check -r /tmp/requirements.txt && rm /tmp/requirements.txt
 
 ENV container=docker
 CMD ["/usr/sbin/init"]

--- a/fedora34-test-container/Dockerfile
+++ b/fedora34-test-container/Dockerfile
@@ -75,7 +75,7 @@ RUN ssh-keygen -A
 RUN systemctl enable sshd.service
 
 COPY requirements.txt /tmp/requirements.txt
-RUN pip3 install --disable-pip-version-check -r /tmp/requirements.txt && rm /tmp/requirements.txt
+RUN pip3 install --no-cache-dir --disable-pip-version-check -r /tmp/requirements.txt && rm /tmp/requirements.txt
 
 ENV container=docker
 CMD ["/usr/sbin/init"]

--- a/opensuse15-test-container/Dockerfile
+++ b/opensuse15-test-container/Dockerfile
@@ -69,7 +69,7 @@ ADD https://ansible-ci-files.s3.amazonaws.com/distro-test-container-files/setupt
   /usr/lib64/python3.6/ensurepip/_bundled/setuptools-44.1.1-py2.py3-none-any.whl
 
 COPY requirements.txt /tmp/requirements.txt
-RUN pip install --disable-pip-version-check -r /tmp/requirements.txt && rm /tmp/requirements.txt
+RUN pip install --no-cache-dir --disable-pip-version-check -r /tmp/requirements.txt && rm /tmp/requirements.txt
 
 ENV container=docker
 CMD ["/sbin/init"]

--- a/opensuse15py2-test-container/Dockerfile
+++ b/opensuse15py2-test-container/Dockerfile
@@ -65,7 +65,7 @@ RUN ssh-keygen -A
 RUN systemctl enable sshd.service
 
 COPY requirements.txt /tmp/requirements.txt
-RUN pip install --disable-pip-version-check -r /tmp/requirements.txt && rm /tmp/requirements.txt
+RUN pip install --no-cache-dir --disable-pip-version-check -r /tmp/requirements.txt && rm /tmp/requirements.txt
 
 ENV container=docker
 CMD ["/sbin/init"]

--- a/ubuntu1804-test-container/Dockerfile
+++ b/ubuntu1804-test-container/Dockerfile
@@ -66,7 +66,7 @@ RUN locale-gen en_US.UTF-8
 VOLUME /sys/fs/cgroup /run/lock /run /tmp
 
 COPY requirements.txt /tmp/requirements.txt
-RUN pip3 install --disable-pip-version-check -r /tmp/requirements.txt && rm /tmp/requirements.txt
+RUN pip3 install --no-cache-dir --disable-pip-version-check -r /tmp/requirements.txt && rm /tmp/requirements.txt
 
 ENV container=docker
 CMD ["/sbin/init"]

--- a/ubuntu2004-test-container/Dockerfile
+++ b/ubuntu2004-test-container/Dockerfile
@@ -66,7 +66,7 @@ RUN locale-gen en_US.UTF-8
 VOLUME /sys/fs/cgroup /run/lock /run /tmp
 
 COPY requirements.txt /tmp/requirements.txt
-RUN pip3 install --disable-pip-version-check -r /tmp/requirements.txt && rm /tmp/requirements.txt
+RUN pip3 install --no-cache-dir --disable-pip-version-check -r /tmp/requirements.txt && rm /tmp/requirements.txt
 
 ENV container=docker
 CMD ["/sbin/init"]


### PR DESCRIPTION
Using "--no-cache-dir" flag in pip install ,make sure dowloaded packages
by pip don't cached on system . This is a best practise which make sure
to fetch ftom repo instead of using local cached one . Further , in case
of Docker Containers , by restricing caching , we can reduce image size.
In term of stats , it depends upon the number of python packages
multiplied by their respective size . e.g for heavy packages with a lot
of dependencies it reduce a lot by don't caching pip packages.

Further , more detail information can be found at

https://medium.com/sciforce/strategies-of-docker-images-optimization-2ca9cc5719b6

Signed-off-by: Pratik Raj <rajpratik71@gmail.com>