### PR TITLE
Remove the VOLUME instruction.

### DIFF
--- a/alpine3-test-container/Dockerfile
+++ b/alpine3-test-container/Dockerfile
@@ -57,8 +57,6 @@ RUN sed -i '/getty/d' /etc/inittab
 # The root account is locked by default, this effectively unlocks it
 RUN echo root:ansible | chpasswd
 
-VOLUME /sys/fs/cgroup /run/lock /run /tmp
-
 COPY requirements.txt /usr/share/container-setup/requirements.txt
 RUN pip3 install --disable-pip-version-check --no-cache-dir -r /usr/share/container-setup/requirements.txt
 

--- a/centos7-test-container/Dockerfile
+++ b/centos7-test-container/Dockerfile
@@ -54,7 +54,6 @@ RUN yum clean all && \
         /usr/share/adobe/resources/*
 
 RUN /usr/bin/sed -i -e 's/^\(Defaults\s*requiretty\)/#--- \1/'  /etc/sudoers
-VOLUME /sys/fs/cgroup /run /tmp
 RUN ssh-keygen -A
 
 COPY requirements.txt /usr/share/container-setup/requirements.txt

--- a/fedora35-test-container/Dockerfile
+++ b/fedora35-test-container/Dockerfile
@@ -67,7 +67,6 @@ RUN /usr/bin/sed -i -e '/pam_loginuid\.so$/ s/required/optional/' /etc/pam.d/*
 # allow ssh-rsa key authentication, which is required for paramiko and EC2 compatibility
 RUN /usr/bin/sed -i -e 's/^PubkeyAcceptedKeyTypes /PubkeyAcceptedKeyTypes ssh-rsa,/' /usr/share/crypto-policies/DEFAULT/openssh.txt
 RUN /usr/bin/sed -i -e 's/^PubkeyAcceptedKeyTypes /PubkeyAcceptedKeyTypes ssh-rsa,/' /usr/share/crypto-policies/DEFAULT/opensshserver.txt
-VOLUME /sys/fs/cgroup /run /tmp
 RUN ssh-keygen -A
 RUN systemctl enable sshd.service
 

--- a/fedora36-test-container/Dockerfile
+++ b/fedora36-test-container/Dockerfile
@@ -67,7 +67,6 @@ RUN /usr/bin/sed -i -e '/pam_loginuid\.so$/ s/required/optional/' /etc/pam.d/*
 # allow ssh-rsa key authentication, which is required for paramiko and EC2 compatibility
 RUN /usr/bin/sed -i -e 's/^PubkeyAcceptedKeyTypes /PubkeyAcceptedKeyTypes ssh-rsa,/' /usr/share/crypto-policies/DEFAULT/openssh.txt
 RUN /usr/bin/sed -i -e 's/^PubkeyAcceptedKeyTypes /PubkeyAcceptedKeyTypes ssh-rsa,/' /usr/share/crypto-policies/DEFAULT/opensshserver.txt
-VOLUME /sys/fs/cgroup /run /tmp
 RUN ssh-keygen -A
 RUN systemctl enable sshd.service
 

--- a/opensuse15-test-container/Dockerfile
+++ b/opensuse15-test-container/Dockerfile
@@ -55,7 +55,6 @@ rm -f ${LIBSYSTEMD}/basic.target.wants/*;
 # don't create systemd-session for ssh connections
 RUN sed -i /pam_systemd/d /etc/pam.d/common-session-pc
 
-VOLUME /sys/fs/cgroup /run /tmp
 RUN ssh-keygen -A
 # explicitly enable the service, opensuse default to disabled services
 RUN systemctl enable sshd.service

--- a/ubuntu2004-test-container/Dockerfile
+++ b/ubuntu2004-test-container/Dockerfile
@@ -61,7 +61,6 @@ RUN apt-get update -y && \
 RUN ln -s /lib/systemd/systemd /sbin/init
 RUN rm /etc/apt/apt.conf.d/docker-clean
 RUN locale-gen en_US.UTF-8
-VOLUME /sys/fs/cgroup /run/lock /run /tmp
 
 COPY requirements.txt /usr/share/container-setup/requirements.txt
 RUN pip3 install --disable-pip-version-check --no-cache-dir -r /usr/share/container-setup/requirements.txt

--- a/ubuntu2204-test-container/Dockerfile
+++ b/ubuntu2204-test-container/Dockerfile
@@ -62,7 +62,6 @@ RUN apt-get update -y && \
 RUN ln -s /lib/systemd/systemd /sbin/init
 RUN rm /etc/apt/apt.conf.d/docker-clean
 RUN locale-gen en_US.UTF-8
-VOLUME /sys/fs/cgroup /run/lock /run /tmp
 
 COPY requirements.txt /usr/share/container-setup/requirements.txt
 RUN pip3 install --disable-pip-version-check --no-cache-dir -r /usr/share/container-setup/requirements.txt


### PR DESCRIPTION
This instruction introduces two issues:

1. Each volume becomes an anonymous volume when the container is run.
   These volumes are not automatically removed unless the `--rm` option is used.
   Instead, create temporary volumes with the `--tmpfs` or `--mount` option, as needed.
2. Specifying a `/sys/fs/cgroup` volume interferes with systemd support.
   The anonymous volume overrides the cgroup mount under both docker and podman.