### PR TITLE
Clean up container builds

### DIFF
--- a/alpine320-test-container/Dockerfile
+++ b/alpine320-test-container/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/bedrock/alpine:3.20.0
+FROM quay.io/bedrock/alpine:3.20.3
 
 # Keep this as basic as possible, so we properly test against BusyBox
 # Things like tar/zip are needed by unarchive

--- a/alpine320-test-container/Dockerfile
+++ b/alpine320-test-container/Dockerfile
@@ -7,7 +7,6 @@ FROM quay.io/bedrock/alpine:3.20.0
 # sshpass was explicitly omitted as BusyBox timeout causes issues with our connection_ssh tests
 RUN apk add --no-cache openrc \
         acl \
-        apache2 \
         bzip2 \
         curl \
         diffutils \
@@ -34,9 +33,7 @@ RUN apk add --no-cache openrc \
         py3-virtualenv \
         py3-yaml \
         py3-wheel \
-        ruby \
         rsync \
-        subversion \
         sudo \
         tar \
         tzdata \

--- a/fedora41-test-container/Dockerfile
+++ b/fedora41-test-container/Dockerfile
@@ -35,10 +35,7 @@ RUN dnf -y upgrade && \
     python3-setuptools \
     python3-virtualenv \
     rpm-build \
-    rubygems \
-    rubygem-rdoc \
     sshpass \
-    subversion \
     sudo \
     systemd \
     tar \

--- a/fedora41-test-container/Dockerfile
+++ b/fedora41-test-container/Dockerfile
@@ -1,7 +1,6 @@
 FROM quay.io/fedora/fedora:41
 
 RUN dnf -y upgrade && \
-    dnf -y install coreutils && \
     dnf -y --setopt=install_weak_deps=false install \
     acl \
     bzip2 \

--- a/ubuntu2204-test-container/Dockerfile
+++ b/ubuntu2204-test-container/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/bedrock/ubuntu:jammy-20240530
+FROM quay.io/bedrock/ubuntu:jammy-20240808
 
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get upgrade -y --no-install-recommends && \

--- a/ubuntu2204-test-container/Dockerfile
+++ b/ubuntu2204-test-container/Dockerfile
@@ -4,7 +4,6 @@ RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get upgrade -y --no-install-recommends && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     acl \
-    apache2 \
     bzip2 \
     curl \
     debhelper \
@@ -44,9 +43,7 @@ RUN apt-get update -y && \
     python3-yaml \
     reprepro \
     rsync \
-    ruby \
     sshpass \
-    subversion \
     sudo \
     systemd \
     tzdata \

--- a/ubuntu2404-test-container/Dockerfile
+++ b/ubuntu2404-test-container/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/bedrock/ubuntu:noble-20240530
+FROM quay.io/bedrock/ubuntu:noble-20241009
 
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get upgrade -y --no-install-recommends && \

--- a/ubuntu2404-test-container/Dockerfile
+++ b/ubuntu2404-test-container/Dockerfile
@@ -4,7 +4,6 @@ RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get upgrade -y --no-install-recommends && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     acl \
-    apache2 \
     bzip2 \
     curl \
     debhelper \
@@ -44,9 +43,7 @@ RUN apt-get update -y && \
     python3-yaml \
     reprepro \
     rsync \
-    ruby \
     sshpass \
-    subversion \
     sudo \
     systemd \
     tzdata \


### PR DESCRIPTION
Clean up container builds:

- Omit additional packages from containers:
  - apache2
  - ruby
  - subversion
- Update base images
- Simplify Fedora setup

Resolves https://github.com/ansible/distro-test-containers/issues/102