### PR TITLE
Install dbus-broker for systemd

### DIFF
--- a/containers/fedora/44/Containerfile
+++ b/containers/fedora/44/Containerfile
@@ -4,6 +4,7 @@ RUN dnf -y upgrade && \
     dnf -y --setopt=install_weak_deps=false install \
     acl \
     bzip2 \
+    dbus-broker \
     file \
     findutils \
     gcc \
@@ -53,6 +54,8 @@ RUN (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i == system
     rm -f /lib/systemd/system/sockets.target.wants/*initctl*; \
     rm -f /lib/systemd/system/basic.target.wants/*; \
     rm -f /lib/systemd/system/anaconda.target.wants/*;
+
+RUN systemctl enable dbus.socket
 
 RUN ssh-keygen -A
 RUN localedef --quiet -c -i en_US -f UTF-8 en_US.UTF-8

--- a/containers/ubuntu/24.04/Containerfile
+++ b/containers/ubuntu/24.04/Containerfile
@@ -6,6 +6,7 @@ RUN apt-get update -y && \
     acl \
     bzip2 \
     curl \
+    dbus-broker \
     debhelper \
     debianutils \
     devscripts \
@@ -46,6 +47,7 @@ RUN apt-get update -y && \
     sshpass \
     sudo \
     systemd \
+    systemd-sysv \
     tzdata \
     unzip \
     virtualenv \
@@ -56,7 +58,6 @@ RUN apt-get update -y && \
     && \
     rm -rf /var/lib/apt/lists/*
 
-RUN ln -s /lib/systemd/systemd /sbin/init
 RUN rm /etc/apt/apt.conf.d/docker-clean
 RUN locale-gen en_US.UTF-8
 

--- a/containers/ubuntu/26.04/Containerfile
+++ b/containers/ubuntu/26.04/Containerfile
@@ -6,6 +6,7 @@ RUN apt-get update -y && \
     acl \
     bzip2 \
     curl \
+    dbus-broker \
     debhelper \
     debianutils \
     devscripts \
@@ -46,6 +47,7 @@ RUN apt-get update -y && \
     sshpass \
     sudo-rs \
     systemd \
+    systemd-sysv \
     tzdata \
     unzip \
     virtualenv \
@@ -56,7 +58,6 @@ RUN apt-get update -y && \
     && \
     rm -rf /var/lib/apt/lists/*
 
-RUN ln -s /lib/systemd/systemd /sbin/init
 RUN rm /etc/apt/apt.conf.d/docker-clean
 RUN locale-gen en_US.UTF-8
 


### PR DESCRIPTION
Fixes #136.

Install the `dbus-broker` package to ensure full systemd capability.
